### PR TITLE
Add V3 support for PGR application creation and related models

### DIFF
--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/config/PGRConfiguration.java
@@ -223,5 +223,8 @@ public class PGRConfiguration {
     @Value("${is.environment.central.instance}")
     private Boolean isEnvironmentCentralInstance;
 
+    // V3 Endpoint to create new pgr application - AI based
+    @Value("${pgr.kafka.createV3.topic}")
+    private String createTopicV3;
 
 }

--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/util/ServiceRequestConverter.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/util/ServiceRequestConverter.java
@@ -1,0 +1,57 @@
+package org.egov.pgr.util;
+
+import org.egov.pgr.web.models.Service;
+import org.egov.pgr.web.models.ServiceRequest;
+import org.egov.pgr.web.modelsV2.ServiceRequestV3;
+import org.egov.pgr.web.modelsV2.ServiceV3;
+
+public class ServiceRequestConverter {
+
+
+    /*
+    * Convert ServiceV3 to Service object
+    * */
+    public static Service toService(ServiceV3 serviceV3) {
+        return Service.builder()
+                .id(serviceV3.getId())
+                .tenantId(serviceV3.getTenantId())
+                .serviceCode(serviceV3.getServiceCode())
+                .serviceRequestId(serviceV3.getServiceRequestId())
+                .description(serviceV3.getDescription())
+                .accountId(serviceV3.getAccountId())
+                .rating(serviceV3.getRating())
+                .additionalDetail(serviceV3.getAdditionalDetail())
+                .applicationStatus(serviceV3.getApplicationStatus())
+                .source(serviceV3.getSource())
+                .address(serviceV3.getAddress())
+                .auditDetails(serviceV3.getAuditDetails())
+                .priority(serviceV3.getPriority())
+                .citizen(serviceV3.getCitizen())
+                .active(serviceV3.isActive())
+                .build();
+    }
+
+    /*
+    * Convert Service to ServiceV3 object
+    * */
+    public static ServiceV3 toServiceV3(Service service) {
+        return ServiceV3.builder()
+                .id(service.getId())
+                .tenantId(service.getTenantId())
+                .serviceCode(service.getServiceCode())
+                .serviceRequestId(service.getServiceRequestId())
+                .description(service.getDescription())
+                .accountId(service.getAccountId())
+                .rating(service.getRating())
+                .additionalDetail(service.getAdditionalDetail())
+                .applicationStatus(service.getApplicationStatus())
+                .source(service.getSource())
+                .address(service.getAddress())
+                .auditDetails(service.getAuditDetails())
+                .priority(service.getPriority())
+                .citizen(service.getCitizen())
+                .active(service.isActive())
+                .build();
+    }
+}
+

--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/controllers/PgrAiControllerV3.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/controllers/PgrAiControllerV3.java
@@ -1,0 +1,49 @@
+package org.egov.pgr.web.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.egov.pgr.service.PGRService;
+import org.egov.pgr.util.ResponseInfoFactory;
+import org.egov.common.contract.response.ResponseInfo;
+import org.egov.pgr.web.models.*;
+import org.egov.pgr.web.modelsV2.ServiceRequestV3;
+import org.egov.pgr.web.modelsV2.ServiceResponseV3;
+import org.egov.pgr.web.modelsV2.ServiceWrapperV3;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.util.*;
+
+import javax.validation.Valid;
+
+public class PgrAiControllerV3 extends RequestsApiController{
+
+    private final ObjectMapper objectMapper;
+
+    private PGRService pgrService;
+
+    private ResponseInfoFactory responseInfoFactory;
+
+    public PgrAiControllerV3(ObjectMapper objectMapper, PGRService pgrService, ResponseInfoFactory responseInfoFactory, ObjectMapper objectMapper1) {
+        super(objectMapper, pgrService, responseInfoFactory);
+        this.objectMapper = objectMapper1;
+    }
+    /**
+     * Endpoint to create a PGR application (V3) by saving a citizen grievance.
+     * The grievance input is categorized using an AI-based LLM model.
+     *
+     * @param request the V3 grievance request payload
+     * @return a response containing the enriched grievance details
+     * @throws IOException in case of any IO-related issues
+     */
+    @RequestMapping(value="/request/v3/_create", method = RequestMethod.POST)
+    public ResponseEntity<ServiceResponseV3> requestsCreateV3(@Valid @RequestBody ServiceRequestV3 request) throws IOException {
+        ServiceRequestV3 enrichedReq = pgrService.createV3(request);
+        ResponseInfo responseInfo = responseInfoFactory.createResponseInfoFromRequestInfo(request.getRequestInfo(), true);
+        ServiceWrapperV3 serviceWrapper = ServiceWrapperV3.builder().service(enrichedReq.getService()).workflow(enrichedReq.getWorkflow()).build();
+        ServiceResponseV3 response = ServiceResponseV3.builder().responseInfo(responseInfo).serviceWrappers(Collections.singletonList(serviceWrapper)).build();
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+}

--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceRequestV3.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceRequestV3.java
@@ -1,0 +1,42 @@
+package org.egov.pgr.web.modelsV2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import lombok.*;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.pgr.web.models.Workflow;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Request object to fetch the report data V3
+ */
+@ApiModel(description = "Request object to fetch the report data")
+@Validated
+@javax.annotation.Generated(value = "org.egov.codegen.SpringBootCodegen", date = "2020-07-15T11:35:33.568+05:30")
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ServiceRequestV3 {
+
+        @NotNull
+        @JsonProperty("RequestInfo")
+        private RequestInfo requestInfo = null;
+
+        @Valid
+        @NonNull
+        @JsonProperty("service")
+        private ServiceV3 service = null;
+
+        @Valid
+        @JsonProperty("workflow")
+        private Workflow workflow = null;
+
+
+}
+

--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceResponseV3.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceResponseV3.java
@@ -1,0 +1,42 @@
+package org.egov.pgr.web.modelsV2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import lombok.*;
+import org.egov.common.contract.response.ResponseInfo;
+import org.egov.pgr.web.models.ServiceWrapper;
+import org.springframework.validation.annotation.Validated;
+
+import java.util.List;
+
+/**
+ * Response to the service request
+ */
+@ApiModel(description = "Response to the service request")
+@Validated
+@javax.annotation.Generated(value = "org.egov.codegen.SpringBootCodegen", date = "2020-07-15T11:35:33.568+05:30")
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ServiceResponseV3 {
+        @JsonProperty("responseInfo")
+        private ResponseInfo responseInfo = null;
+
+        @JsonProperty("ServiceWrappers")
+        private List<ServiceWrapperV3> serviceWrappers = null;
+        
+        @JsonProperty("complaintsResolved")
+        private int complaintsResolved;
+
+        @JsonProperty("averageResolutionTime")
+        private int averageResolutionTime;
+
+        @JsonProperty("complaintTypes")
+        private int complaintTypes;
+
+
+}
+

--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceV3.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceV3.java
@@ -1,0 +1,103 @@
+package org.egov.pgr.web.modelsV2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import lombok.*;
+import org.egov.pgr.annotation.CharacterConstraint;
+import org.egov.pgr.web.models.Address;
+import org.egov.pgr.web.models.AuditDetails;
+import org.egov.pgr.web.models.Priority;
+import org.egov.pgr.web.models.User;
+import org.hibernate.validator.constraints.SafeHtml;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Instance of Service request raised for a particular service. As per extension propsed in the Service definition \&quot;attributes\&quot; carry the input values requried by metadata definition in the structure as described by the corresponding schema.  * Any one of &#39;address&#39; or &#39;(lat and lang)&#39; or &#39;addressid&#39; is mandatory 
+ */
+@ApiModel(description = "Instance of Service request raised for a particular service. As per extension propsed in the Service definition \"attributes\" carry the input values requried by metadata definition in the structure as described by the corresponding schema.  * Any one of 'address' or '(lat and lang)' or 'addressid' is mandatory ")
+@Validated
+@javax.annotation.Generated(value = "org.egov.codegen.SpringBootCodegen", date = "2020-07-15T11:35:33.568+05:30")
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ServiceV3 {
+
+        @JsonProperty("active")
+        private boolean active = true;
+
+        @JsonProperty("citizen")
+        private User citizen = null;
+
+        @SafeHtml
+        @JsonProperty("id")
+        private String id = null;
+
+        @NotNull
+        @SafeHtml
+        @JsonProperty("tenantId")
+        private String tenantId = null;
+
+        @NotNull
+        @SafeHtml
+        @JsonProperty("serviceCode")
+        private String serviceCode = null;
+
+        @SafeHtml
+        @JsonProperty("serviceRequestId")
+        private String serviceRequestId = null;
+
+        @SafeHtml
+        @JsonProperty("description")
+        private String description = null;
+
+        @SafeHtml
+        @JsonProperty("accountId")
+        private String accountId = null;
+
+        @Max(5)
+        @Min(1)
+        @JsonProperty("rating")
+        private Integer rating ;
+
+        @CharacterConstraint(size = 600)
+        @JsonProperty("additionalDetail")
+        private Object additionalDetail = null;
+
+        @SafeHtml
+        @JsonProperty("applicationStatus")
+        private String applicationStatus = null;
+
+        @NotNull
+        @SafeHtml
+        @JsonProperty("source")
+        private String source = null;
+
+        @Valid
+        @NotNull
+        @JsonProperty("address")
+        private Address address = null;
+
+        @JsonProperty("auditDetails")
+        private AuditDetails auditDetails = null;
+
+        @NotNull
+        @JsonProperty("priority")
+        private Priority priority = null;
+
+        @SafeHtml
+        @JsonProperty("serviceType")
+        private String serviceType = null;
+
+        @SafeHtml
+        @JsonProperty("inputGrievance")
+        private String inputGrievance = null;
+}
+

--- a/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceWrapperV3.java
+++ b/municipal-services/pgr-services/src/main/java/org/egov/pgr/web/modelsV2/ServiceWrapperV3.java
@@ -1,0 +1,26 @@
+package org.egov.pgr.web.modelsV2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.egov.pgr.web.models.Service;
+import org.egov.pgr.web.models.Workflow;
+
+import javax.validation.Valid;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ServiceWrapperV3 {
+
+
+    @Valid
+    @NonNull
+    @JsonProperty("service")
+    private ServiceV3 service = null;
+
+    @Valid
+    @JsonProperty("workflow")
+    private Workflow workflow = null;
+
+}

--- a/municipal-services/pgr-services/src/main/resources/db/migration/main/V20250501153020__add_new_v3_tables.sql
+++ b/municipal-services/pgr-services/src/main/resources/db/migration/main/V20250501153020__add_new_v3_tables.sql
@@ -1,0 +1,90 @@
+
+CREATE TABLE IF NOT EXISTS ug_pgr_service_v3
+(
+    id character varying(64),
+    tenantid character varying(256) NOT NULL,
+    servicecode character varying(256) NOT NULL,
+    servicerequestid character varying(256) NOT NULL,
+    description character varying(4000),
+    accountid character varying(256),
+    additionaldetails jsonb,
+    applicationstatus character varying(128),
+    rating smallint,
+    source character varying(256),
+	createdby character varying(256) NOT NULL,
+    createdtime bigint NOT NULL,
+    lastmodifiedby character varying(256),
+    lastmodifiedtime bigint,
+    active boolean DEFAULT true,
+    serviceType character varying(256),
+    grievanceinput character varying(256),
+    CONSTRAINT pk_eg_pgr_servicereq_v2 PRIMARY KEY (tenantid, servicerequestid),
+    CONSTRAINT uk_ug_pgr_service_v3 UNIQUE (id)
+)
+
+TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS index_ug_pgr_service_v3_accountid
+    ON ug_pgr_service_v3 USING btree
+    (accountid ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS index_ug_pgr_service_v3_applicationstatus
+    ON ug_pgr_service_v3 USING btree
+    (applicationstatus ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS index_ug_pgr_service_v3_id
+    ON ug_pgr_service_v3 USING btree
+    (id ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS index_ug_pgr_service_v3_servicecode
+    ON ug_pgr_service_v3 USING btree
+    (grievanceType ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS index_ug_pgr_service_v3_tenantid_servicerequestid
+    ON grievanceType USING btree
+    (tenantid ASC NULLS LAST, servicerequestid ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+
+
+CREATE TABLE IF NOT EXISTS ug_pgr_address_v3
+(
+    tenantid character varying(256) NOT NULL,
+    id character varying(256) NOT NULL,
+    parentid character varying(256) NOT NULL,
+    doorno character varying(128), 
+    plotno character varying(256), 
+    buildingname character varying(1024), 
+    street character varying(1024),
+    landmark character varying(1024),
+    city character varying(512),
+    pincode character varying(16),
+    locality character varying(128) NOT NULL,
+    district character varying(256),
+    region character varying(256),
+    state character varying(256),
+    country character varying(512),
+    latitude numeric(9,6),
+    longitude numeric(10,7),
+    createdby character varying(128) NOT NULL,
+    createdtime bigint NOT NULL,
+    lastmodifiedby character varying(128),
+    lastmodifiedtime bigint,
+    additionaldetails jsonb,
+    CONSTRAINT pk_eg_pgr_address_v2 PRIMARY KEY (id),
+    CONSTRAINT fk_eg_pgr_address_v2 FOREIGN KEY (parentid)
+        REFERENCES ug_pgr_service_v3 (id) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE NO ACTION
+)
+
+TABLESPACE pg_default;
+
+CREATE INDEX IF NOT EXISTS index_ug_pgr_address_v3_locality
+    ON ug_pgr_address_v3 USING btree
+    (locality ASC NULLS LAST)
+    TABLESPACE pg_default;


### PR DESCRIPTION
- Introduced new V3 endpoint for creating PGR applications using AI-based categorization.
- Added ServiceRequestV3, ServiceResponseV3, ServiceV3, and ServiceWrapperV3 models.
- Implemented ServiceRequestConverter for converting between V2 and V3 service models.
- Created database migration script for new V3 tables and indices.