### PR TITLE
1507 - Add grievance processing functionality to persist data in ES

### DIFF
--- a/municipal-services/pgr-ai-services/pom.xml
+++ b/municipal-services/pgr-ai-services/pom.xml
@@ -131,7 +131,21 @@
             <version>7.2.0</version>
             <type>pom</type>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Hoxton.SR12</version> <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <repositories>
         <repository>
             <id>repo.digit.org</id>

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/PGRAiApp.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/PGRAiApp.java
@@ -8,6 +8,7 @@ import org.egov.tracer.config.TracerConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
@@ -24,6 +25,7 @@ import java.util.TimeZone;
  *
  * This class is the entry point for the Spring Boot application.
  */
+@EnableFeignClients
 @SpringBootApplication
 @ComponentScan(basePackages = { "org.upyog.pgrai", "org.upyog.pgrai.web.controllers" , "org.upyog.pgrai.config"})
 @Import({TracerConfiguration.class, MultiStateInstanceUtil.class})

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/config/PGRConfiguration.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/config/PGRConfiguration.java
@@ -231,4 +231,7 @@ public class PGRConfiguration {
     @Value("${egov.grievance.es.consumer.topic}")
     private String grievanceEsConsumerTopic;
 
+    @Value("${grievance.consumer.enabled:true}")
+    private boolean isConsumerEnabled;
+
 }

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/config/PGRConfiguration.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/config/PGRConfiguration.java
@@ -227,5 +227,8 @@ public class PGRConfiguration {
     @Value("${is.environment.central.instance}")
     private Boolean isEnvironmentCentralInstance;
 
+    // grievance elasticsearch consumer topic
+    @Value("${egov.grievance.es.consumer.topic}")
+    private String grievanceEsConsumerTopic;
 
 }

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/consumer/GrievanceConsumer.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/consumer/GrievanceConsumer.java
@@ -10,6 +10,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
+import org.upyog.pgrai.config.PGRConfiguration;
 import org.upyog.pgrai.service.GrievanceFeignClient;
 import org.upyog.pgrai.web.models.ServiceRequest;
 import org.upyog.pgrai.web.models.grievanceClient.Grievance;
@@ -25,8 +26,8 @@ public class GrievanceConsumer {
     @Autowired
     private GrievanceFeignClient grievanceFeignClient;
 
-    @Value("${grievance.consumer.enabled:true}")
-    private boolean isConsumerEnabled;
+    @Autowired
+    private PGRConfiguration pgrConfiguration;
 
     /**
      * Kafka consumer that listens to grievance creation topic and forwards the request
@@ -38,7 +39,7 @@ public class GrievanceConsumer {
     @KafkaListener(topics = {"${egov.grievance.es.consumer.topic}"})
     public void consume(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
 
-        if (!isConsumerEnabled) {
+        if (!pgrConfiguration.isConsumerEnabled()) {
             log.info("Grievance consumer is disabled via configuration.");
             return;
         }

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/consumer/GrievanceConsumer.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/consumer/GrievanceConsumer.java
@@ -1,0 +1,63 @@
+package org.upyog.pgrai.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import org.upyog.pgrai.service.GrievanceFeignClient;
+import org.upyog.pgrai.web.models.ServiceRequest;
+import org.upyog.pgrai.web.models.grievanceClient.Grievance;
+import org.upyog.pgrai.web.models.grievanceClient.GrievanceMapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class GrievanceConsumer {
+
+    @Autowired
+    private GrievanceFeignClient grievanceFeignClient;
+
+    @Value("${grievance.consumer.enabled:true}")
+    private boolean isConsumerEnabled;
+
+    /**
+     * Kafka consumer that listens to grievance creation topic and forwards the request
+     * to another service using Feign Client.
+     *
+     * @param record the incoming Kafka message payload
+     * @param topic  the Kafka topic the message was received from
+     */
+    @KafkaListener(topics = {"${egov.grievance.es.consumer.topic}"})
+    public void consume(final HashMap<String, Object> record, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+
+        if (!isConsumerEnabled) {
+            log.info("Grievance consumer is disabled via configuration.");
+            return;
+        }
+
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            ServiceRequest request = mapper.convertValue(record, ServiceRequest.class);
+            Grievance grievance = GrievanceMapper.toGrievance(request);
+            Map<String, String> response = grievanceFeignClient.createGrievance(grievance);
+
+            log.info("Grievance created with response: {}", response);
+        }
+        catch (FeignException fe) {
+            log.error("Feign client error: {} - {}", fe.status(), fe.getMessage(), fe);
+        }
+        catch (IllegalArgumentException je) {
+            log.error("JSON conversion error: {}", je.getMessage(), je);
+        }
+        catch (Exception e) {
+            log.error("Unhandled exception while processing grievance request: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/service/GrievanceFeignClient.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/service/GrievanceFeignClient.java
@@ -1,0 +1,25 @@
+package org.upyog.pgrai.service;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.upyog.pgrai.web.models.grievanceClient.Grievance;
+
+import java.util.Map;
+
+/**
+ * Feign client for sending grievance data to the FastAPI service.
+ */
+@FeignClient(name = "grievance-api", url = "http://35.154.83.250:5002")
+public interface GrievanceFeignClient {
+
+    /**
+     * Calls FastAPI endpoint to create a new grievance.
+     *
+     * @param grievance Grievance data to be sent.
+     * @return Map with grievance ID and status.
+     */
+    @PostMapping("/grievances")
+    Map<String, String> createGrievance(@RequestBody Grievance grievance);
+}
+

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/service/GrievanceFeignClient.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/service/GrievanceFeignClient.java
@@ -10,7 +10,7 @@ import java.util.Map;
 /**
  * Feign client for sending grievance data to the FastAPI service.
  */
-@FeignClient(name = "grievance-api", url = "http://35.154.83.250:5002")
+@FeignClient(name = "grievance-api", url = "${grievance.api.url}")
 public interface GrievanceFeignClient {
 
     /**

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/service/PGRService.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/service/PGRService.java
@@ -71,6 +71,7 @@ public class PGRService {
         enrichmentService.enrichCreateRequest(request);
         workflowService.updateWorkflowStatus(request);
         producer.push(tenantId,config.getCreateTopic(),request);
+        producer.push(tenantId,config.getGrievanceEsConsumerTopic(),request);
         return request;
     }
 

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/web/models/grievanceClient/Grievance.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/web/models/grievanceClient/Grievance.java
@@ -1,0 +1,85 @@
+package org.upyog.pgrai.web.models.grievanceClient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Grievance {
+
+    @JsonProperty("tenantId")
+    private String tenantId;
+
+    @JsonProperty("serviceCode")
+    private String serviceCode;
+
+    @JsonProperty("serviceType")
+    private String serviceType;
+
+    @JsonProperty("serviceRequestType")
+    private String serviceRequestType;
+
+    @JsonProperty("rating")
+    private Integer rating;
+
+    @JsonProperty("applicationStatus")
+    private String applicationStatus;
+
+    @JsonProperty("source")
+    private String source;
+
+    @JsonProperty("latitude")
+    private Double latitude;
+
+    @JsonProperty("longitude")
+    private Double longitude;
+
+    @JsonProperty("locality")
+    private String locality;
+
+    @JsonProperty("landmark")
+    private String landmark;
+
+    @JsonProperty("pincode")
+    private String pincode;
+
+    @JsonProperty("city")
+    private String city;
+
+    @JsonProperty("state")
+    private String state;
+
+    @JsonProperty("priority")
+    private String priority;
+
+    @JsonProperty("inputGrievance")
+    private String inputGrievance;
+
+    @JsonProperty("workflow")
+    private String workflow;
+
+    @JsonProperty("currentState")
+    private String currentState;
+
+    @JsonProperty("businessService")
+    private String businessService;
+
+    @JsonProperty("action")
+    private String action;
+
+    @JsonProperty("assigner")
+    private String assigner;
+
+    @JsonProperty("assignee")
+    private String assignee;
+
+    @JsonProperty("comments")
+    private String comments;
+
+    @JsonProperty("grievanceId")
+    private String grievanceId;
+
+}
+

--- a/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/web/models/grievanceClient/GrievanceMapper.java
+++ b/municipal-services/pgr-ai-services/src/main/java/org/upyog/pgrai/web/models/grievanceClient/GrievanceMapper.java
@@ -1,0 +1,48 @@
+package org.upyog.pgrai.web.models.grievanceClient;
+
+import org.upyog.pgrai.web.models.Address;
+import org.upyog.pgrai.web.models.Service;
+import org.upyog.pgrai.web.models.ServiceRequest;
+
+/**
+ * Utility class for mapping a ServiceRequest object to a Grievance object.
+ * This class provides a static method to transform the data from the service request
+ * into a format suitable for grievance processing.
+ */
+public class GrievanceMapper {
+
+    /**
+     * Converts a ServiceRequest object into a Grievance object.
+     *
+     * @param request The ServiceRequest object containing the service and address details.
+     * @return A Grievance object populated with data from the provided ServiceRequest.
+     */
+    public static Grievance toGrievance(ServiceRequest request) {
+        Service service = request.getService();
+        Address address = service.getAddress();
+
+        return Grievance.builder()
+                .tenantId(service.getTenantId())
+                .serviceCode(service.getServiceCode())
+                .serviceType(service.getServiceType())
+                .rating(service.getRating())
+                .applicationStatus(service.getApplicationStatus())
+                .source(service.getSource())
+                .latitude(address.getGeoLocation() != null ? address.getGeoLocation().getLatitude() : null)
+                .longitude(address.getGeoLocation() != null ? address.getGeoLocation().getLongitude() : null)
+                .locality(address.getLocality() != null ? address.getLocality().getName() : null)
+                .landmark(address.getLandmark())
+                .pincode(address.getPincode())
+                .city(address.getCity())
+                .state(address.getState())
+                .priority(service.getPriority() != null ? service.getPriority().name() : null)
+                .inputGrievance(service.getInputGrievance())
+                .businessService(service.getServiceCode()) // or another appropriate field
+                .action(request.getWorkflow() != null ? request.getWorkflow().getAction() : null)
+//                .assignee(request.getWorkflow() != null ? request.getWorkflow().getAssignes().get(0) : null)
+                .assignee(null)
+                .comments(request.getWorkflow() != null ? request.getWorkflow().getComments() : null)
+                .grievanceId(service.getServiceRequestId())
+                .build();
+    }
+}

--- a/municipal-services/pgr-ai-services/src/main/resources/application.properties
+++ b/municipal-services/pgr-ai-services/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 server.contextPath=/pgr-ai-services
 server.context-path=/pgr-ai-services
 server.servlet.context-path=/pgr-ai-services
-server.port=8280
+server.port=8080
 app.timezone=UTC
 
 # KAFKA SERVER CONFIGURATIONS
@@ -128,6 +128,12 @@ persister.save.transition.wf.migration.topic=save-wf-transitions-batch
 # central-instance configs
 state.level.tenantid.length=1
 is.environment.central.instance=false
+
+# grievance elastic search config
+egov.grievance.es.consumer.topic=save-es-grievance
+
+# Enable or disable grievance Kafka consumer
+grievance.consumer.enabled=true
 
 pgr.kafka.notification.topic.pattern=((^[a-zA-Z]+-)?save-pgr-ai-request|(^[a-zA-Z]+-)?update-ai-pgr-request)
 

--- a/municipal-services/pgr-ai-services/src/main/resources/application.properties
+++ b/municipal-services/pgr-ai-services/src/main/resources/application.properties
@@ -129,6 +129,9 @@ persister.save.transition.wf.migration.topic=save-wf-transitions-batch
 state.level.tenantid.length=1
 is.environment.central.instance=false
 
+# grievance service api host
+grievance.api.url=https://35.154.83.250
+
 # grievance elastic search config
 egov.grievance.es.consumer.topic=save-es-grievance
 


### PR DESCRIPTION
- Introduced GrievanceConsumer to listen for grievance creation events and forward requests using Feign client.
- Added GrievanceFeignClient for communication with the FastAPI service.
- Created GrievanceMapper to convert ServiceRequest to Grievance object.
- Updated PGRService to publish grievances to the appropriate Kafka topic.
- Added configuration properties for grievance consumer and Elasticsearch topic.
- Included necessary dependencies in pom.xml and enabled Feign clients in PGRAiApp.