### PR TITLE
migrate react-query v3 to @tanstack/react-query v5 across pt, ptr, receipts, reports, surveys, sv, tl, useInboxGeneral, vendor, ws, wt folders

### DIFF
--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/common/queryClientTemplate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/common/queryClientTemplate.js
@@ -1,0 +1,3 @@
+import {useQueryClient } from "@tanstack/react-query";
+
+export { useQueryClient };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/UseCustomBackNavigationProps.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/UseCustomBackNavigationProps.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
+import useCustomNavigate from './useCustomNavigate';
 
 /**
  * Custom hook to handle back button navigation
@@ -15,28 +15,25 @@ export const useCustomBackNavigation = ({
   enableConfirmation = false,
   confirmationMessage = 'Are you sure you want to leave this page?'
 }) => {
-  const history = useHistory();
+  const navigate = useCustomNavigate();
 
   useEffect(() => {
     // Add a new entry to browser's history stack
     window.history.pushState(null, '', window.location.pathname);
 
-    const handleBackButton = (event) => {
-      // Prevent default back navigation
-      event.preventDefault();
-
+    const handleBackButton = () => {
       if (enableConfirmation) {
         // Show confirmation dialog if enabled
         const shouldRedirect = window.confirm(confirmationMessage);
         if (shouldRedirect) {
-          history.push(redirectPath);
+          navigate(redirectPath);
         } else {
-          // If user cancels, push a new state to prevent back navigation
+          // Prevent back navigation by re-pushing state
           window.history.pushState(null, '', window.location.pathname);
         }
       } else {
         // Directly redirect without confirmation
-        history.push(redirectPath);
+        navigate(redirectPath);
       }
     };
 
@@ -47,5 +44,5 @@ export const useCustomBackNavigation = ({
     return () => {
       window.removeEventListener('popstate', handleBackButton);
     };
-  }, [history, redirectPath, enableConfirmation, confirmationMessage]);
+  }, [navigate, redirectPath, enableConfirmation, confirmationMessage]);
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/index.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/index.js
@@ -354,6 +354,8 @@ import useEnabledMDMS from "./useEnabledMDMS";
 import useSelectedMDMS from "./useSelectedMDMS";
 import useRouteSubscription from "./useRouteSubscription";
 import { useCustomBackNavigation } from "./UseCustomBackNavigationProps";
+import useCustomNavigate from "./useCustomNavigate";
+
 
 const pgr = {
   useComplaintDetails,
@@ -791,6 +793,7 @@ const Hooks = {
   useSelectedMDMS,
   useRouteSubscription,
   useCustomBackNavigation,
+  useCustomNavigate,
   pgrAi,
   useInbox
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/payment.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/payment.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { PaymentService } from "../services/elements/Payment";
 
 export const useFetchCitizenBillsForBuissnessService = ({ businessService, ...filters }, config = {}) => {
@@ -20,26 +21,27 @@ export const useFetchCitizenBillsForBuissnessService = ({ businessService, ...fi
       isError: false,
       data: null,
       status: 'skipped',
-      revalidate: () => queryClient.invalidateQueries(["citizenBillsForBuisnessService", businessService]),
+      revalidate: () => queryClient.invalidateQueries({ queryKey: ["citizenBillsForBuisnessService", businessService] }),
     };
   }
 
-  const { isLoading, error, isError, data, status } = useQuery(
-    ["citizenBillsForBuisnessService", businessService, { ...params }],
-    () => Digit.PaymentService.fetchBill(window.location.href.includes("mcollect")?tenant:tenantId, { ...params }),
-    {
+  const { isLoading, error, isError, data, status } = queryTemplate({
+    queryKey: ["citizenBillsForBuisnessService", businessService, { ...params }],
+    queryFn: () => Digit.PaymentService.fetchBill(window.location.href.includes("mcollect")?tenant:tenantId, { ...params }),
+    config: {
       refetchOnMount: true,
       retry: false,
       ...config,
     }
-  );
+  });
+
   return {
     isLoading,
     error,
     isError,
     data,
     status,
-    revalidate: () => queryClient.invalidateQueries(["citizenBillsForBuisnessService", businessService]),
+    revalidate: () => queryClient.invalidateQueries({ queryKey: ["citizenBillsForBuisnessService", businessService] }),
   };
 };
 
@@ -48,23 +50,25 @@ export const useFetchBillsForBuissnessService = ({ tenantId, businessService, ..
   let isPTAccessDone = sessionStorage.getItem("IsPTAccessDone");
   const params = { businessService, ...filters };
   const _tenantId = tenantId || Digit.UserService.getUser()?.info?.tenantId;
-  const { isLoading, error, isError, data, status } = useQuery(
-    ["billsForBuisnessService", businessService, { ...filters }, config, isPTAccessDone],
-    () => Digit.PaymentService.fetchBill(_tenantId, params),
-    {
+
+  const { isLoading, error, isError, data, status } = queryTemplate({
+    queryKey: ["billsForBuisnessService", businessService, { ...filters }, config, isPTAccessDone],
+    queryFn: () => Digit.PaymentService.fetchBill(_tenantId, params),
+    config: {
       retry: (count, err) => {
         return false;
       },
       ...config,
     }
-  );
+  });
+
   return {
     isLoading,
     error,
     isError,
     data,
     status,
-    revalidate: () => queryClient.invalidateQueries(["billsForBuisnessService", businessService]),
+    revalidate: () => queryClient.invalidateQueries({ queryKey: ["billsForBuisnessService", businessService] }),
   };
 };
 
@@ -105,11 +109,15 @@ export const useFetchPayment = ({ tenantId, consumerCode, businessService }, con
     else return failureCount < 3;
   };
 
-  const queryData = useQuery(["paymentFetchDetails", tenantId, consumerCode, businessService], () => fetchBill(), { retry, ...config });
+  const queryData = queryTemplate({
+    queryKey: ["paymentFetchDetails", tenantId, consumerCode, businessService],
+    queryFn: () => fetchBill(),
+    config: { retry, ...config }
+  });
 
   return {
     ...queryData,
-    revalidate: () => queryClient.invalidateQueries(["paymentFetchDetails", tenantId, consumerCode, businessService]),
+    revalidate: () => queryClient.invalidateQueries({ queryKey: ["paymentFetchDetails", tenantId, consumerCode, businessService] }),
   };
 };
 
@@ -122,15 +130,24 @@ export const usePaymentUpdate = ({ egId }, businessService, config) => {
     return { payments, applicationNo: transaction.Transaction[0].consumerCode, txnStatus: transaction.Transaction[0].txnStatus };
   };
 
-  return useQuery(["paymentUpdate", egId], () => getPaymentData(egId), config);
+  return queryTemplate({
+    queryKey: ["paymentUpdate", egId],
+    queryFn: () => getPaymentData(egId),
+    config
+  });
 };
 
 export const useGetPaymentRulesForBusinessServices = (tenantId) => {
-  return useQuery(["getPaymentRules", tenantId], () => Digit.MDMSService.getPaymentRules(tenantId));
+  return queryTemplate({
+    queryKey: ["getPaymentRules", tenantId],
+    queryFn: () => Digit.MDMSService.getPaymentRules(tenantId),
+  });
 };
 
 export const usePaymentSearch = (tenantId, filters, config = {}) => {
-  return useQuery(["PAYMENT_SERACH", tenantId], () => Digit.PaymentService.searchBill(tenantId, filters), {
+  return queryTemplate({
+    queryKey: ["PAYMENT_SERACH", tenantId],
+    queryFn: () => Digit.PaymentService.searchBill(tenantId, filters),
     select: (data) => {
       return data?.Bill?.[0]?.billDetails?.[0]?.billAccountDetails.filter((e) => {
         switch (e.taxHeadCode) {
@@ -151,49 +168,57 @@ export const usePaymentSearch = (tenantId, filters, config = {}) => {
         }
       });
     },
-    ...config,
+    config,
   });
 };
 
 export const useDemandSearch = ({ consumerCode, businessService, tenantId }, config = {}) => {
   if (!tenantId) tenantId = Digit.ULBService.getCurrentTenantId();
   const queryFn = () => Digit.PaymentService.demandSearch(tenantId, consumerCode, businessService);
-  const queryData = useQuery(["demand_search", { consumerCode, businessService, tenantId }], queryFn, { refetchOnMount: "always", ...config });
+  const queryData = queryTemplate({
+    queryKey: ["demand_search", { consumerCode, businessService, tenantId }],
+    queryFn,
+    config: { refetchOnMount: "always", ...config }
+  });
   return queryData;
 };
 
 export const useAssetQrCode = ({ tenantId, ...params }, config = {}) => {     
-  return useQuery(
-    ["assets_Reciept_Search", { tenantId, params },config],
-    () => Digit.PaymentService.useAssetQrCodeService(tenantId, params),
-    {
+  return queryTemplate({
+    queryKey: ["assets_Reciept_Search", { tenantId, params },config],
+    queryFn: () => Digit.PaymentService.useAssetQrCodeService(tenantId, params),
+    config: {
       refetchOnMount: false,
       ...config,
     }
-  );
+  });
 };
 
 export const useRecieptSearch = ({ tenantId, businessService, ...params }, config = {}) => {
-  return useQuery(
-    ["reciept_search", { tenantId, businessService, params },config],
-    () => Digit.PaymentService.recieptSearch(tenantId, businessService, params),
-    {
+  return queryTemplate({
+    queryKey: ["reciept_search", { tenantId, businessService, params },config],
+    queryFn: () => Digit.PaymentService.recieptSearch(tenantId, businessService, params),
+    config: {
       refetchOnMount: false,
       ...config,
     }
-  );
+  });
 };
+
 export const useRecieptSearchNew = ({ tenantId, ...params }, config = {}) => {
-  return useQuery(
-    ["obps_Reciept_Search", { tenantId, params },config],
-    () => Digit.PaymentService.recieptSearchNew(tenantId, params),
-    {
+  return queryTemplate({
+    queryKey: ["obps_Reciept_Search", { tenantId, params },config],
+    queryFn: () => Digit.PaymentService.recieptSearchNew(tenantId, params),
+    config: {
       refetchOnMount: false,
       ...config,
     }
-  );
+  });
 };
 
 export const useBulkPdfDetails = ({ filters }) => {
-  return useQuery(["BULK_PDF_DETAILS", filters], async () => await PaymentService.getBulkPdfRecordsDetails(filters));
+  return queryTemplate({
+    queryKey: ["BULK_PDF_DETAILS", filters],
+    queryFn: async () => await PaymentService.getBulkPdfRecordsDetails(filters)
+  });
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/UseAssessmentCreateUlb.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/UseAssessmentCreateUlb.js
@@ -1,9 +1,10 @@
 import { PTService } from "../../services/elements/PT";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const UseAssessmentCreateUlb = (tenantId, config = {}) => {
   console.log("Using AssessmentCreateUlb",tenantId)
-  return useMutation((data) => PTService.assessmentCreateUlb(data, tenantId));
+  const mutationFn = (data) => PTService.assessmentCreateUlb(data, tenantId);
+  return mutationTemplate({ mutationFn });
 };
 
 export default UseAssessmentCreateUlb;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useApplicationActions.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useApplicationActions.js
@@ -1,8 +1,9 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActions from "../../services/molecules/PT/ApplicationUpdateActions";
 
 const useApplicationActions = (tenantId) => {
-  return useMutation((applicationData) => ApplicationUpdateActions(applicationData, tenantId));
+  const mutationFn = (applicationData) => ApplicationUpdateActions(applicationData, tenantId);
+  return mutationTemplate({ mutationFn });
 };
 
 export default useApplicationActions;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useApplicationDetail.js
@@ -1,5 +1,5 @@
 import { PTSearch } from "../../services/molecules/PT/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useApplicationDetail = (t, tenantId, propertyIds, config = {}, userType, args) => {
   const defaultSelect = (data) => {
@@ -17,12 +17,19 @@ const useApplicationDetail = (t, tenantId, propertyIds, config = {}, userType, a
     return { ...data, applicationDetails };
   };
 
-  return useQuery(
-    ["APPLICATION_SEARCH", "PT_SEARCH", propertyIds, userType, args],
-    () => PTSearch.applicationDetails(t, tenantId, propertyIds, userType, args),
-    { select: defaultSelect, ...config }
-    // config
-  );
+  const queryKey = ["APPLICATION_SEARCH", "PT_SEARCH", propertyIds, userType, args];
+
+  const queryFn = () => PTSearch.applicationDetails(t, tenantId, propertyIds, userType, args);
+
+  const select = defaultSelect;
+
+  return queryTemplate({
+    queryKey,
+    queryFn,
+    select,
+    config,
+  });
+  // config
 };
 
 export default useApplicationDetail;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useGenderMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useGenderMDMS.js
@@ -1,9 +1,9 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const useGenderMDMS = (tenantId, moduleCode, type, config = {}) => {
   const useGenderDetails = () => {
-    return useQuery("PT_GENDER_DETAILS", () => MdmsService.getGenderType(tenantId, moduleCode ,type), config);
+    return queryTemplate({ queryKey: ["PT_GENDER_DETAILS"], queryFn: () => MdmsService.getGenderType(tenantId, moduleCode ,type), config });
   };
   
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useGenericViewProperty.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useGenericViewProperty.js
@@ -1,34 +1,16 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { PTSearch } from "../../services/molecules/PT/Search";
 
-/**
- * Custom hook which can be used to
- * get the property search using property id and tenant id 
- * and return the property generic template to show employee and citizen view
- * 
- * @author jagankumar-egov
- * 
- * @example
- *  Digit.Hooks.pt.useGenericViewProperty(t,
- *                                        tenantId, 
- *                                        propertyId,
- *                                        { // all configs supported by the usequery 
- *                                                  default:(data)=>{
- *                                                                   format
- *                                                                   return formattedData;
- *                                                                   }
- *                                        });
- * 
- * @returns {Object} Returns the object of the useQuery from react-query.
- */
 const useGenericViewProperty = (t, tenantId, propertyIds, config = {}, userType) => {
   const defaultSelect = (data) => {
     return { ...data };
   };
 
-  return useQuery(["VIEW_GENERIC_PROPERTY", propertyIds, tenantId], () => PTSearch.genericPropertyDetails(t, tenantId, propertyIds), {
+  return queryTemplate({
+    queryKey: ["VIEW_GENERIC_PROPERTY", propertyIds, tenantId],
+    queryFn: () => PTSearch.genericPropertyDetails(t, tenantId, propertyIds),
     select: defaultSelect,
-    ...config,
+    config,
   });
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useGenericViewProperty.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useGenericViewProperty.js
@@ -1,6 +1,25 @@
 import { queryTemplate } from "../../common/queryTemplate";
 import { PTSearch } from "../../services/molecules/PT/Search";
 
+/**
+ * Custom hook which can be used to
+ * get the property search using property id and tenant id 
+ * and return the property generic template to show employee and citizen view
+ * 
+ * 
+ * @example
+ *  Digit.Hooks.pt.useGenericViewProperty(t,
+ *                                        tenantId, 
+ *                                        propertyId,
+ *                                        { // all configs supported by the usequery 
+ *                                                  default:(data)=>{
+ *                                                                   format
+ *                                                                   return formattedData;
+ *                                                                   }
+ *                                        });
+ * 
+ * @returns {Object} Returns the object of the useQuery from react-query.
+ */
 const useGenericViewProperty = (t, tenantId, propertyIds, config = {}, userType) => {
   const defaultSelect = (data) => {
     return { ...data };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useMDMS.js
@@ -1,17 +1,17 @@
 import { MdmsService, getGeneralCriteria } from "../../services/elements/MDMS";
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useMDMS = (tenantId, moduleCode, type, config = { }, payload = []) => {
   const useFinancialYears = () => {
-    return useQuery("PT_FINANCIAL_YEARLS", () => MdmsServiceV2.getDataByCriteria(tenantId, payload, moduleCode));
+    return queryTemplate({ queryKey: ["PT_FINANCIAL_YEARLS"], queryFn: () => MdmsServiceV2.getDataByCriteria(tenantId, payload, moduleCode) });
   };
   const useCommonFieldsConfig = () => {
-    return useQuery("COMMON_FIELDS", () => MdmsService.getCommonFieldsConfig(tenantId, moduleCode, type, payload));
+    return queryTemplate({ queryKey: ["COMMON_FIELDS"], queryFn: () => MdmsService.getCommonFieldsConfig(tenantId, moduleCode, type, payload) });
   };
 
   const usePropertyTaxDocuments = () => {
-    return useQuery("PT_PROPERTY_TAX_DOCUMENTS", () => MdmsServiceV2.getDataByCriteria(tenantId, payload, moduleCode));
+    return queryTemplate({ queryKey: ["PT_PROPERTY_TAX_DOCUMENTS"], queryFn: () => MdmsServiceV2.getDataByCriteria(tenantId, payload, moduleCode) });
   };
 
   /*const useGenderDetails = () => {
@@ -29,7 +29,7 @@ const useMDMS = (tenantId, moduleCode, type, config = { }, payload = []) => {
       return useGenderDetails();*/
 
     default:
-      return useQuery(type, () => MdmsServiceV2.getDataByCriteria(tenantId, getGeneralCriteria(tenantId, moduleCode, type), moduleCode), config);
+      return queryTemplate({ queryKey: [type], queryFn: () => MdmsServiceV2.getDataByCriteria(tenantId, getGeneralCriteria(tenantId, moduleCode, type), moduleCode), config });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useMyPropertyPayments.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useMyPropertyPayments.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const getOwnerForPayments = (propertyData,data) => {
   let newPayments = [];
@@ -16,12 +17,10 @@ const useMyPropertyPayments = ({ tenantId, filters, searchedFrom="" }, config = 
   const paymentargs = tenantId ? { tenantId, filters } : { filters };
 
 
-  const { isLoading, error, data } = useQuery(["paymentpropertySearchList", tenantId, filters], () => Digit.PTService.paymentsearch(paymentargs), {
-    ...config,
-    });
-  let updatedData = getOwnerForPayments(config?.propertyData,data);
+  const { isLoading, error, data } = queryTemplate({ queryKey: ["paymentpropertySearchList", tenantId, filters], queryFn: () => Digit.PTService.paymentsearch(paymentargs), config });
+  const updatedData = getOwnerForPayments(config?.propertyData, data);
 
-return { isLoading, error, data, revalidate: () => client.invalidateQueries(["paymentpropertySearchList", tenantId, filters]) };
+return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["paymentpropertySearchList", tenantId, filters] }) };
 
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePTGenderMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePTGenderMDMS.js
@@ -1,12 +1,11 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
 
 const usePTGenderMDMS = (tenantId, moduleCode, type, config = {}) => {
   const usePTGenders = () => {
-    return useQuery("PT_FORM_GENDER_DETAILS", () => MdmsServiceV2.PTGenderType(tenantId, moduleCode ,type), config);
+    return queryTemplate({ queryKey: ["PT_FORM_GENDER_DETAILS"], queryFn: () => MdmsServiceV2.PTGenderType(tenantId, moduleCode, type), config });
   };
-  
 
   switch (type) {
     case "GenderType":

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyAPI.js
@@ -1,11 +1,11 @@
 import { PTService } from "../../services/elements/PT";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const usePropertyAPI = (tenantId, type = true) => {
   if (type) {
-    return useMutation((data) => PTService.create(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => PTService.create(data, tenantId) });
   } else {
-    return useMutation((data) => PTService.update(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => PTService.update(data, tenantId) });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyAssessment.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyAssessment.js
@@ -1,8 +1,8 @@
 import { PTService } from "../../services/elements/PT";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const usePropertyAssessment = (tenantId, config = {}) => {
-  return useMutation((data) => PTService.assessmentCreate(data, tenantId));
+  return mutationTemplate({ mutationFn: (data) => PTService.assessmentCreate(data, tenantId) });
 };
 
 export default usePropertyAssessment;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyCreateNUpdateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyCreateNUpdateAPI.js
@@ -1,15 +1,15 @@
 import { PTService } from "../../services/elements/PT";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const usePropertyCreateNUpdateAPI = (tenantId, update = false) => {
-  let mutation = useMutation(async (data) => { 
+  let mutation = mutationTemplate({ mutationFn: async (data) => { 
     const createdProp = await PTService.create(data, tenantId)
     if(createdProp?.ResponseInfo && createdProp?.ResponseInfo?.status === "successful") {
       if(update) {
         await PTService.update(createdProp?.Properties[0], tenantId)
       }
     }
-  });
+  } });
 
   return mutation;
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyDocumentSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyDocumentSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const usePropertyDocumentSearch = ({ property }, config = {}) => {
   const client = useQueryClient();
@@ -6,8 +7,8 @@ const usePropertyDocumentSearch = ({ property }, config = {}) => {
   const tenant = Digit.ULBService.getStateId();
   const propertyId = property?.propertyId;
   const filesArray = property?.documents?.map((value) => value?.fileStoreId);
-  const { isLoading, error, data } = useQuery([`ptDocuments-${propertyId}`, filesArray], () => Digit.UploadServices.Filefetch(filesArray, tenant));
-  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries([`ptDocuments-${propertyId}`, filesArray]) };
+  const { isLoading, error, data } = queryTemplate({ queryKey: [`ptDocuments-${propertyId}`, filesArray], queryFn: () => Digit.UploadServices.Filefetch(filesArray, tenant) });
+  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries({ queryKey: [`ptDocuments-${propertyId}`, filesArray] }) };
 };
 
 export default usePropertyDocumentSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyMDMS.js
@@ -1,41 +1,41 @@
 import { MdmsService } from "../../services/elements/MDMS";
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const usePropertyMDMS = (tenantId, moduleCode, type, config = {}) => {
   const usePropertyOwnerType = () => {
-    return useQuery("PT_OWNERSHIP_CATEGORY", () => MdmsServiceV2.getPropertyOwnerType(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["PT_OWNERSHIP_CATEGORY"], queryFn: () => MdmsServiceV2.getPropertyOwnerType(tenantId, moduleCode, type), config });
   };
   const usePropertyOwnerShipCategory = () => {
-    return useQuery("PT_OWNER_TYPE", () => MdmsServiceV2.getPropertyOwnerShipCategory(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["PT_OWNER_TYPE"], queryFn: () => MdmsServiceV2.getPropertyOwnerShipCategory(tenantId, moduleCode, type), config });
   };
   const useSubOwnerShipCategory = () => {
-    return useQuery("PT_SUB_OWNERSHIP_CATEGORY", () => MdmsServiceV2.getPropertySubOwnerShipCategory(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["PT_SUB_OWNERSHIP_CATEGORY"], queryFn: () => MdmsServiceV2.getPropertySubOwnerShipCategory(tenantId, moduleCode, type), config });
   };
   const useDocumentRequiredScreen = () => {
-    return useQuery("PT_DOCUMENT_REQ_SCREEN", () => MdmsServiceV2.getDocumentRequiredScreen(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["PT_DOCUMENT_REQ_SCREEN"], queryFn: () => MdmsServiceV2.getDocumentRequiredScreen(tenantId, moduleCode), config });
   };
   const useUsageCategory = () => {
-    return useQuery("PT_USAGE_CATEGORY", () => MdmsServiceV2.getUsageCategory(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["PT_USAGE_CATEGORY"], queryFn: () => MdmsServiceV2.getUsageCategory(tenantId, moduleCode, type), config });
   };
   const usePTPropertyType = () => {
-    return useQuery("PT_PROPERTY_TYPE", () => MdmsServiceV2.getPTPropertyType(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["PT_PROPERTY_TYPE"], queryFn: () => MdmsServiceV2.getPTPropertyType(tenantId, moduleCode, type), config });
   };
   const useRentalDetails = () => {
-    return useQuery("PT_RENTAL_DETAILS", () => MdmsServiceV2.getRentalDetails(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["PT_RENTAL_DETAILS"], queryFn: () => MdmsServiceV2.getRentalDetails(tenantId, moduleCode), config });
   };
   const useChargeSlabs = () => {
-    return useQuery("PT_RENTAL_DETAILS", () => MdmsServiceV2.getChargeSlabs(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["PT_RENTAL_DETAILS"], queryFn: () => MdmsServiceV2.getChargeSlabs(tenantId, moduleCode), config });
   };
   const useFloorList = () => {
-    return useQuery("PT_FLOOR_LIST", () => MdmsServiceV2.getFloorList(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["PT_FLOOR_LIST"], queryFn: () => MdmsServiceV2.getFloorList(tenantId, moduleCode), config });
   };
   const useMapConfig = () => {
-    return useQuery("PT_MAP_CONFIG", () => MdmsServiceV2.getMapConfig(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["PT_MAP_CONFIG"], queryFn: () => MdmsServiceV2.getMapConfig(tenantId, moduleCode), config });
   };
 
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsServiceV2.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsServiceV2.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyPayment.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertyPayment.js
@@ -1,13 +1,13 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const usePropertyPayment = ({ tenantId, consumerCodes }) => {
   const client = useQueryClient();
-  const { isLoading, error, data } = useQuery(
-    ["propertyPaymentList", tenantId, consumerCodes],
-    () => Digit.PTService.fetchPaymentDetails({ tenantId, consumerCodes }),
-    {}
-  );
-  return { isLoading, error, data, revalidate: () => client.invalidateQueries(["propertyPaymentList", tenantId, consumerCodes]) };
+  const { isLoading, error, data } = queryTemplate({
+    queryKey: ["propertyPaymentList", tenantId, consumerCodes],
+    queryFn: () => Digit.PTService.fetchPaymentDetails({ tenantId, consumerCodes }),
+  });
+  return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["propertyPaymentList", tenantId, consumerCodes] }) };
 };
 
 export default usePropertyPayment;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertySearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertySearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const usePropertySearch = ({ tenantId, filters, auth,searchedFrom="" }, config = {}) => {
   const client = useQueryClient();
@@ -17,12 +18,9 @@ const usePropertySearch = ({ tenantId, filters, auth,searchedFrom="" }, config =
     return data;
   };
 
-  const { isLoading, error, data, isSuccess } = useQuery(["propertySearchList", tenantId, filters, auth, config], () => Digit.PTService.search(args), {
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ["propertySearchList", tenantId, filters, auth, config], queryFn: () => Digit.PTService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries(["propertySearchList", tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: ["propertySearchList", tenantId, filters, auth] }) };
 };
 
 export default usePropertySearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertySearchNew.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertySearchNew.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const usePropertySearchNew = ({ tenantId, filters, auth,searchedFrom="" }, config = {}) => {
   const client = useQueryClient();
@@ -17,12 +18,9 @@ const usePropertySearchNew = ({ tenantId, filters, auth,searchedFrom="" }, confi
     return data;
   };
 
-  const { isLoading, error, data, isSuccess } = useQuery(["propertySearchList", tenantId, filters, auth], () => Digit.PTService.search(args), {
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ["propertySearchList", tenantId, filters, auth], queryFn: () => Digit.PTService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries(["propertySearchList", tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: ["propertySearchList", tenantId, filters, auth] }) };
 };
 
 export default usePropertySearchNew;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertySearchWithDue.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePropertySearchWithDue.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { useQuery } from "@tanstack/react-query";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const usePropertySearchWithDue = ({ tenantId, filters, auth = true, configs }) => {
   const client = useQueryClient();
@@ -34,29 +35,30 @@ const usePropertySearchWithDue = ({ tenantId, filters, auth = true, configs }) =
     return data;
   };
 
-  const { isLoading, error, data } = useQuery(
-    ["propertySearchList", tenantId, filters, auth],
-    () => configs.enabled && Digit.PTService.search({ tenantId, filters, auth: auth }),
-    {...configs,
-      select: defaultSelect,
-    }
-  );
+  const { isLoading, error, data } = useQuery({
+    queryKey: ["propertySearchList", tenantId, filters, auth],
+    queryFn: () => configs.enabled && Digit.PTService.search({ tenantId, filters, auth }),
+    select: defaultSelect,
+    ...configs,
+  });
+
   let consumerCodes = data?.ConsumerCodes?.join(",") || "";
-  const { isLoading: billLoading, data: billData, isSuccess } = useQuery(
-    ["propertySearchBillList", tenantId, filters, data, auth, consumerCodes],
-    () => configs.enabled && data && Digit.PTService.fetchPaymentDetails({ tenantId, consumerCodes, auth: auth }),
-    {...configs,
-      select: (billResp) => {
-        data["Bill"] =
-          billResp?.Bill?.reduce((curr, acc) => {
-            curr[acc?.consumerCode] = acc?.totalAmount;
-            data["FormattedData"][acc?.consumerCode]["due"] = acc?.totalAmount;
-            return curr;
-          }, {}) || {};
-        return billResp;
-      },
-    }
-  );
+
+  const { isLoading: billLoading, data: billData, isSuccess } = useQuery({
+    queryKey: ["propertySearchBillList", tenantId, filters, data, auth, consumerCodes],
+    queryFn: () => configs.enabled && data && Digit.PTService.fetchPaymentDetails({ tenantId, consumerCodes, auth }),
+    select: (billResp) => {
+      data["Bill"] =
+        billResp?.Bill?.reduce((curr, acc) => {
+          curr[acc?.consumerCode] = acc?.totalAmount;
+          data["FormattedData"][acc?.consumerCode]["due"] = acc?.totalAmount;
+          return curr;
+        }, {}) || {};
+      return billResp;
+    },
+    ...configs,
+  });
+
   return {
     isLoading: isLoading || billLoading,
     error,
@@ -64,8 +66,8 @@ const usePropertySearchWithDue = ({ tenantId, filters, auth = true, configs }) =
     billData,
     isSuccess,
     revalidate: () => {
-      client.invalidateQueries(["propertySearchBillList", tenantId, filters, auth]);
-      client.invalidateQueries(["propertySearchList", tenantId, filters, auth]);
+      client.invalidateQueries({ queryKey: ["propertySearchBillList", tenantId, filters, auth] });
+      client.invalidateQueries({ queryKey: ["propertySearchList", tenantId, filters, auth] });
     },
   };
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePtCalculationEstimate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/usePtCalculationEstimate.js
@@ -1,8 +1,8 @@
 import { PTService } from "../../services/elements/PT";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const usePtCalculationEstimate = (tenantId, config = {}) => {
-  return useMutation((data) => PTService.ptCalculationEstimate(data, tenantId));
+  return mutationTemplate({ mutationFn: (data) => PTService.ptCalculationEstimate(data, tenantId) });
 };
 
 export default usePtCalculationEstimate;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useRatingAndFeedbackMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useRatingAndFeedbackMDMS.js
@@ -1,14 +1,12 @@
-import React from "react";
-import { useQuery } from "react-query";
-import { MdmsService } from "../../services/elements/MDMS";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
 
 const useRatingAndFeedbackMDMS = {
     RatingAndFeedBack: (tenantId) =>
-    useQuery(
-      [tenantId, "PT_MDMS_RATING_AND_FEEDBACK_VALUES"],
-      () =>
-      MdmsServicV2.getDataByCriteria(
+    queryTemplate({
+      queryKey: [tenantId, "PT_MDMS_RATING_AND_FEEDBACK_VALUES"],
+      queryFn: () =>
+      MdmsServiceV2.getDataByCriteria(
           tenantId,
           {
             details: {
@@ -27,10 +25,8 @@ const useRatingAndFeedbackMDMS = {
           },
           "PT"
         ),
-      {
-        select: (data) =>  data?.["common-masters"]?.RatingAndFeedback?.reduce((obj, item) => (obj[item.type] = item.value, obj) ,{}),
-      }
-    ),
+      select: (data) =>  data?.["common-masters"]?.RatingAndFeedback?.reduce((obj, item) => (obj[item.type] = item.value, obj) ,{}),
+    }),
 };
 
 export default useRatingAndFeedbackMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useServiceSearchCF.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/pt/useServiceSearchCF.js
@@ -1,25 +1,19 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useServiceSearchCF = ({ tenantId, filters }, config = {}) => {
   const client = useQueryClient();
-  //removing servicedefids from search call as it's not required anymore
-  // const searchargs = { filters : { ServiceDefinitionCriteria : {tenantId : filters?.serviceSearchArgs?.tenantId, module:filters?.serviceSearchArgs?.module, code:filters?.serviceSearchArgs?.code  }}};
 
+  let serviceSearchArg = { filters: { ServiceCriteria: { tenantId: filters?.serviceSearchArgs?.tenantId, referenceIds: filters?.serviceSearchArgs?.referenceIds } } };
+  let serviceconfig = { ...config, cacheTime: 0 };
 
-  // const { isLoading, error, data } = useQuery(["ServiceDefinitionSearch", tenantId, filters], () => Digit.PTService.cfdefinitionsearch(searchargs), {
-  //   ...config,
-  //   });
+  const { isLoading: serviceLoading, error: serviceerror, data: servicedata } = queryTemplate({
+    queryKey: ["ServiceSearch", tenantId, filters],
+    queryFn: () => Digit.PTService.cfsearch(serviceSearchArg),
+    config: serviceconfig,
+  });
 
-let serviceSearchArg = {filters : {ServiceCriteria : {tenantId:filters?.serviceSearchArgs?.tenantId, /*serviceDefIds: [data?.ServiceDefinition?.[0]?.id]["ca134821-97f0-42b7-a53d-f6cd2796e4b9"],attributes:filters?.serviceSearchArgs?.attributes*/ referenceIds:filters?.serviceSearchArgs?.referenceIds}}}
-let serviceconfig = {/*enabled : data?.ServiceDefinition?.[0]?.id ? true : false,*/...config, cacheTime: 0}
-
-const { isLoading : serviceLoading, error : serviceerror, data :servicedata} = useQuery(["ServiceSearch", tenantId, filters], () => Digit.PTService.cfsearch(serviceSearchArg), {
-    ...serviceconfig,
-    });
-
-
-return {isLoading: serviceLoading, error : serviceerror, data : servicedata, revalidate: () => client.invalidateQueries(["ServiceSearch", tenantId, filters]) };
-
+  return { isLoading: serviceLoading, error: serviceerror, data: servicedata, revalidate: () => client.invalidateQueries({ queryKey: ["ServiceSearch", tenantId, filters] }) };
 };
 
 export default useServiceSearchCF;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/useBreedTypeMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/useBreedTypeMDMS.js
@@ -1,14 +1,15 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
- const useBreed = (tenantId, moduleCode, type, config = {}) => {
-   return useQuery("PTR_FORM_BREED_TYPE", () => MdmsService.PTRBreedType(tenantId, moduleCode ,type), config);
- };
+const useBreed = (tenantId, moduleCode, type, config = {}) => {
+  return queryTemplate({ queryKey: ["PTR_FORM_BREED_TYPE"], queryFn: () => MdmsService.PTRBreedType(tenantId, moduleCode, type), config });
+};
 
- const useBreedTypeMDMS = (tenantId, moduleCode, type,  config = {}) => {
-   if (type === "BreedType") {
-     return useBreed(tenantId, moduleCode, type, config);
-   }
-   return null;
- };
+const useBreedTypeMDMS = (tenantId, moduleCode, type, config = {}) => {
+  if (type === "BreedType") {
+    return useBreed(tenantId, moduleCode, type, config);
+  }
+  return null;
+};
+
 export default useBreedTypeMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/useMyPetPayments.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/useMyPetPayments.js
@@ -1,28 +1,25 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
-const getOwnerForPayments = (propertyData,data) => {
+const getOwnerForPayments = (propertyData, data) => {
   let newPayments = [];
   data && data?.Payments?.map((payment) => {
     let owner = propertyData?.filter((ob) => ob.propertyId === payment?.paymentDetails?.[0]?.bill?.consumerCode)[0]?.owners;
-    newPayments.push({...payment,owners:owner});
-  })
+    newPayments.push({ ...payment, owners: owner });
+  });
   data ? data["Payments"] = [...newPayments] : "";
   return data;
-}
+};
 
-const useMyPetPayments = ({ tenantId, filters, searchedFrom="" }, config = {}) => {
+const useMyPetPayments = ({ tenantId, filters, searchedFrom = "" }, config = {}) => {
   const client = useQueryClient();
 
   const paymentargs = tenantId ? { tenantId, filters } : { filters };
 
+  const { isLoading, error, data } = queryTemplate({ queryKey: ["paymentpetSearchList", tenantId, filters], queryFn: () => Digit.PTRService.paymentsearch(paymentargs), config });
+  const updatedData = getOwnerForPayments(config?.propertyData, data);
 
-  const { isLoading, error, data } = useQuery(["paymentpetSearchList", tenantId, filters], () => Digit.PTRService.paymentsearch(paymentargs), {
-    ...config,
-    });
-  let updatedData = getOwnerForPayments(config?.propertyData,data);
-
-return { isLoading, error, data, revalidate: () => client.invalidateQueries(["paymentpetSearchList", tenantId, filters]) };
-
+  return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["paymentpetSearchList", tenantId, filters] }) };
 };
 
 export default useMyPetPayments;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRApplicationAction.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRApplicationAction.js
@@ -1,8 +1,9 @@
-import { useMutation } from "react-query";
-import ApplicationUpdateActionsPTR from "../../services/molecules/PTR/ApplicationUpdateActionsPTR"
+import { mutationTemplate } from "../../common/mutationTemplate";
+import ApplicationUpdateActionsPTR from "../../services/molecules/PTR/ApplicationUpdateActionsPTR";
 
 const usePTRApplicationAction = (tenantId) => {
-  return useMutation((applicationData) => ApplicationUpdateActionsPTR(applicationData, tenantId));
+  const mutationFn = (applicationData) => ApplicationUpdateActionsPTR(applicationData, tenantId);
+  return mutationTemplate({ mutationFn });
 };
 
 export default usePTRApplicationAction;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRCreateAPI.js
@@ -1,14 +1,11 @@
-import { useQuery, useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import { PTRService } from "../../services/elements/PTR";
 
-
 export const usePTRCreateAPI = (tenantId, type = true) => {
- // return useMutation((data) => PTRService.create(data, tenantId));
   if (type) {
-    return useMutation((data) => PTRService.create(data, tenantId));
-  } 
-  else {
-    return useMutation((data) => PTRService.update(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => PTRService.create(data, tenantId) });
+  } else {
+    return mutationTemplate({ mutationFn: (data) => PTRService.update(data, tenantId) });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRGenderMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRGenderMDMS.js
@@ -1,11 +1,10 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const usePTRGenderMDMS = (tenantId, moduleCode, type, config = {}) => {
   const usePTRGenders = () => {
-    return useQuery("PTR_GENDER_DETAILS", () => MdmsService.PTRGenderType(tenantId, moduleCode ,type), config);
+    return queryTemplate({ queryKey: ["PTR_GENDER_DETAILS"], queryFn: () => MdmsService.PTRGenderType(tenantId, moduleCode, type), config });
   };
-  
 
   switch (type) {
     case "GenderType":
@@ -14,7 +13,5 @@ const usePTRGenderMDMS = (tenantId, moduleCode, type, config = {}) => {
       return null;
   }
 };
-
-
 
 export default usePTRGenderMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRPetMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRPetMDMS.js
@@ -1,7 +1,8 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const usePTRPetMDMS = (tenantId, moduleCode, type, config = {}) => {
-  return useQuery("PTR_FORM_PET_TYPE", () => MdmsService.PTRPetType(tenantId, moduleCode ,type), config);
+  return queryTemplate({ queryKey: ["PTR_FORM_PET_TYPE"], queryFn: () => MdmsService.PTRPetType(tenantId, moduleCode, type), config });
 };
+
 export default usePTRPetMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePTRSearch.js
@@ -1,23 +1,19 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
-const usePTRSearch = ({ tenantId, filters, auth,searchedFrom="" }, config = {}) => {
+const usePTRSearch = ({ tenantId, filters, auth, searchedFrom = "" }, config = {}) => {
   const client = useQueryClient();
 
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
 
   const defaultSelect = (data) => {
-    // console.log("ptrhook", data)
-    if(data.PetRegistrationApplications.length > 0)  data.PetRegistrationApplications[0].owners = data.PetRegistrationApplications[0].owners || [];
-      
+    if (data.PetRegistrationApplications.length > 0) data.PetRegistrationApplications[0].owners = data.PetRegistrationApplications[0].owners || [];
     return data;
   };
 
-  const { isLoading, error, data, isSuccess } = useQuery(["ptrSearchList", tenantId, filters, auth, config], () => Digit.PTRService.search(args), {
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ["ptrSearchList", tenantId, filters, auth, config], queryFn: () => Digit.PTRService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries(["ptrSearchList", tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: ["ptrSearchList", tenantId, filters, auth] }) };
 };
 
 export default usePTRSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePetDocumentSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePetDocumentSearch.js
@@ -1,13 +1,13 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const usePetDocumentSearch = ({ petdetail }, config = {}) => {
   const client = useQueryClient();
-  const tenantId = petdetail?.tenantId || Digit.ULBService.getCurrentTenantId();
   const tenant = Digit.ULBService.getStateId();
   const applicationNumber = petdetail?.propertyId;
   const filesArray = petdetail?.documents?.map((value) => value?.filestoreId);
-  const { isLoading, error, data } = useQuery([`ptDocuments-${applicationNumber}`, filesArray], () => Digit.UploadServices.Filefetch(filesArray, tenant));
-  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries([`ptDocuments-${applicationNumber}`, filesArray]) };
+  const { isLoading, error, data } = queryTemplate({ queryKey: [`ptDocuments-${applicationNumber}`, filesArray], queryFn: () => Digit.UploadServices.Filefetch(filesArray, tenant) });
+  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries({ queryKey: [`ptDocuments-${applicationNumber}`, filesArray] }) };
 };
 
 export default usePetDocumentSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePetMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePetMDMS.js
@@ -1,25 +1,18 @@
 import { MdmsService } from "../../services/elements/MDMS";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const usePetMDMS = (tenantId, moduleCode, type, config = {}) => {
-  
-  
-  
   const usePetDocumentsRequiredScreen = () => {
-    return useQuery("PT_DOCUMENT_REQ_SCREEN", () => MdmsService.getPetDocumentsRequiredScreen(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["PT_DOCUMENT_REQ_SCREEN"], queryFn: () => MdmsService.getPetDocumentsRequiredScreen(tenantId, moduleCode), config });
   };
-  
-  
 
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {
-    
     case "Documents":
       return usePetDocumentsRequiredScreen();
-    
     default:
       return _default();
   }

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePtrApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/usePtrApplicationDetail.js
@@ -1,24 +1,24 @@
 import { PTRSearch } from "../../services/molecules/PTR/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { usePetColors } from "./usePetColors";
 
 const usePtrApplicationDetail = (t, tenantId, applicationNumber, config = {}, userType, args) => {
-  
   const defaultSelect = (data) => {
-    let applicationDetails = data.applicationDetails
+    let applicationDetails = data.applicationDetails;
     return {
-      applicationData : data,
-      applicationDetails
-    }
+      applicationData: data,
+      applicationDetails,
+    };
   };
 
   const pet_color = usePetColors().data;
-  return useQuery(
-    ["APPLICATION_SEARCH", "PT_SEARCH", applicationNumber,pet_color, userType, args],
-    () => PTRSearch.applicationDetails(t, tenantId, applicationNumber,pet_color, userType, args),
-    { select: defaultSelect, ...config }
- 
-  );
+
+  return queryTemplate({
+    queryKey: ["APPLICATION_SEARCH", "PT_SEARCH", applicationNumber, pet_color, userType, args],
+    queryFn: () => PTRSearch.applicationDetails(t, tenantId, applicationNumber, pet_color, userType, args),
+    select: defaultSelect,
+    config,
+  });
 };
 
 export default usePtrApplicationDetail;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/useServiceSearchPTR.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ptr/useServiceSearchPTR.js
@@ -1,26 +1,19 @@
-
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useServiceSearchPTR = ({ tenantId, filters }, config = {}) => {
   const client = useQueryClient();
-  //removing servicedefids from search call as it's not required anymore
-  // const searchargs = { filters : { ServiceDefinitionCriteria : {tenantId : filters?.serviceSearchArgs?.tenantId, module:filters?.serviceSearchArgs?.module, code:filters?.serviceSearchArgs?.code  }}};
 
+  const serviceSearchArg = { filters: { ServiceCriteria: { tenantId: filters?.serviceSearchArgs?.tenantId, referenceIds: filters?.serviceSearchArgs?.referenceIds } } };
+  const serviceconfig = { ...config, cacheTime: 0 };
 
-  // const { isLoading, error, data } = useQuery(["ServiceDefinitionSearch", tenantId, filters], () => Digit.PTService.cfdefinitionsearch(searchargs), {
-  //   ...config,
-  //   });
+  const { isLoading: serviceLoading, error: serviceerror, data: servicedata } = queryTemplate({
+    queryKey: ["ServiceSearch", tenantId, filters],
+    queryFn: () => Digit.PTService.cfsearch(serviceSearchArg),
+    config: serviceconfig,
+  });
 
-let serviceSearchArg = {filters : {ServiceCriteria : {tenantId:filters?.serviceSearchArgs?.tenantId, /*serviceDefIds: [data?.ServiceDefinition?.[0]?.id]["ca134821-97f0-42b7-a53d-f6cd2796e4b9"],attributes:filters?.serviceSearchArgs?.attributes*/ referenceIds:filters?.serviceSearchArgs?.referenceIds}}}
-let serviceconfig = {/*enabled : data?.ServiceDefinition?.[0]?.id ? true : false,*/...config, cacheTime: 0}
-
-const { isLoading : serviceLoading, error : serviceerror, data :servicedata} = useQuery(["ServiceSearch", tenantId, filters], () => Digit.PTService.cfsearch(serviceSearchArg), {
-    ...serviceconfig,
-    });
-
-
-return {isLoading: serviceLoading, error : serviceerror, data : servicedata, revalidate: () => client.invalidateQueries(["ServiceSearch", tenantId, filters]) };
-
+  return { isLoading: serviceLoading, error: serviceerror, data: servicedata, revalidate: () => client.invalidateQueries({ queryKey: ["ServiceSearch", tenantId, filters] }) };
 };
 
 export default useServiceSearchPTR;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/receipts/useReceiptsMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/receipts/useReceiptsMDMS.js
@@ -1,69 +1,48 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const useReceiptsMDMS = (tenantId, type, config = {}) => {
+  const client = useQueryClient();
+
   const useReceiptsBusinessServices = () => {
-    const { isLoading, error, data } = useQuery(["RECEIPTS_SERVICES", tenantId], () => MdmsService.getReceiptKey(tenantId, 'common-masters'), config);
-    if (!isLoading && data && data[`common-masters`] && data[`common-masters`]?.uiCommonPay && Array.isArray(data[`common-masters`].uiCommonPay)) {
+    const { isLoading, error, data } = queryTemplate({ queryKey: ["RECEIPTS_SERVICES", tenantId], queryFn: () => MdmsService.getReceiptKey(tenantId, "common-masters"), config });
+    if (!isLoading && data && data[`common-masters`]?.uiCommonPay && Array.isArray(data[`common-masters`].uiCommonPay)) {
       data[`common-masters`].uiCommonPay = data[`common-masters`].uiCommonPay.filter((unit) => unit.cancelReceipt) || [];
-      data.dropdownData = [...data[`common-masters`].uiCommonPay.map(config => {
-        return {
-          code: config.code,
-          name: `BILLINGSERVICE_BUSINESSSERVICE_${config.code}`
-        }
-      })] || []
+      data.dropdownData = data[`common-masters`].uiCommonPay.map((cfg) => ({ code: cfg.code, name: `BILLINGSERVICE_BUSINESSSERVICE_${cfg.code}` }));
     }
-    return { isLoading, error, data, revalidate: () => client.invalidateQueries(["RECEIPTS_SERVICES", tenantId]) };
+    return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["RECEIPTS_SERVICES", tenantId] }) };
   };
 
   const useCancelReceiptReason = () => {
-    const { isLoading, error, data } = useQuery(["RECEIPTS_CANCEL_REASON", tenantId], () => MdmsService.getCancelReceiptReason(tenantId, 'common-masters'), config);
-    if (!isLoading && data && data[`common-masters`] && data[`common-masters`]?.CancelReceiptReason && Array.isArray(data[`common-masters`].CancelReceiptReason)) {
+    const { isLoading, error, data } = queryTemplate({ queryKey: ["RECEIPTS_CANCEL_REASON", tenantId], queryFn: () => MdmsService.getCancelReceiptReason(tenantId, "common-masters"), config });
+    if (!isLoading && data && data[`common-masters`]?.CancelReceiptReason && Array.isArray(data[`common-masters`].CancelReceiptReason)) {
       data[`common-masters`].CancelReceiptReason = data[`common-masters`].CancelReceiptReason.filter((unit) => unit.active) || [];
-      data.dropdownData = [...data[`common-masters`].CancelReceiptReason.map(config => {
-        return {
-          code: config.code,
-          name: `CR_REASON_${config.code}`
-        }
-      })] || []
+      data.dropdownData = data[`common-masters`].CancelReceiptReason.map((cfg) => ({ code: cfg.code, name: `CR_REASON_${cfg.code}` }));
     }
-    return { isLoading, error, data, revalidate: () => client.invalidateQueries(["RECEIPTS_CANCEL_REASON", tenantId]) };
+    return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["RECEIPTS_CANCEL_REASON", tenantId] }) };
   };
+
   const useCancelReceiptStatus = () => {
-    const { isLoading, error, data } = useQuery(["RECEIPTS_CANCEL_STATUS", tenantId], () => MdmsService.getReceiptStatus(tenantId, 'common-masters'), config);
-    if (!isLoading && data && data[`common-masters`] && data[`common-masters`]?.ReceiptStatus && Array.isArray(data[`common-masters`].ReceiptStatus)) {
+    const { isLoading, error, data } = queryTemplate({ queryKey: ["RECEIPTS_CANCEL_STATUS", tenantId], queryFn: () => MdmsService.getReceiptStatus(tenantId, "common-masters"), config });
+    if (!isLoading && data && data[`common-masters`]?.ReceiptStatus && Array.isArray(data[`common-masters`].ReceiptStatus)) {
       data[`common-masters`].ReceiptStatus = data[`common-masters`].ReceiptStatus.filter((unit) => unit.active) || [];
-      data.dropdownData = [...data[`common-masters`].ReceiptStatus.map(config => {
-        return {
-          code: config.code,
-          name: `RC_${config.code}`
-        }
-      })] || []
+      data.dropdownData = data[`common-masters`].ReceiptStatus.map((cfg) => ({ code: cfg.code, name: `RC_${cfg.code}` }));
     }
-    return { isLoading, error, data, revalidate: () => client.invalidateQueries(["RECEIPTS_CANCEL_STATUS", tenantId]) };
+    return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["RECEIPTS_CANCEL_STATUS", tenantId] }) };
   };
+
   const useCancelReceiptReasonAndStatus = () => {
-    const { isLoading, error, data } = useQuery(["RECEIPTS_CANCEL_REASON_STATUS", tenantId], () => MdmsService.getCancelReceiptReasonAndStatus(tenantId, 'common-masters'), config);
-    if (!isLoading && data && data[`common-masters`] && data[`common-masters`]?.uiCommonPay && Array.isArray(data[`common-masters`].uiCommonPay)) {
+    const { isLoading, error, data } = queryTemplate({ queryKey: ["RECEIPTS_CANCEL_REASON_STATUS", tenantId], queryFn: () => MdmsService.getCancelReceiptReasonAndStatus(tenantId, "common-masters"), config });
+    if (!isLoading && data && data[`common-masters`]?.uiCommonPay && Array.isArray(data[`common-masters`].uiCommonPay)) {
       data[`common-masters`].uiCommonPay = data[`common-masters`].uiCommonPay.filter((unit) => unit.cancelReceipt) || [];
-      data.dropdownData = [...data[`common-masters`].uiCommonPay.map(config => {
-        return {
-          code: config.code,
-          name: `BILLINGSERVICE_BUSINESSSERVICE_${config.code}`
-        }
-      })] || []
+      data.dropdownData = data[`common-masters`].uiCommonPay.map((cfg) => ({ code: cfg.code, name: `BILLINGSERVICE_BUSINESSSERVICE_${cfg.code}` }));
       if (data[`common-masters`]?.ReceiptStatus && Array.isArray(data[`common-masters`].ReceiptStatus)) {
         data[`common-masters`].ReceiptStatus = data[`common-masters`].ReceiptStatus.filter((unit) => unit.active) || [];
-        data.dropdownDataStatus = [...data[`common-masters`].ReceiptStatus.map(config => {
-          return {
-            code: config.code,
-            name: `RC_${config.code}`
-          }
-        })] || []
+        data.dropdownDataStatus = data[`common-masters`].ReceiptStatus.map((cfg) => ({ code: cfg.code, name: `RC_${cfg.code}` }));
       }
-
     }
-    return { isLoading, error, data, revalidate: () => client.invalidateQueries(["RECEIPTS_CANCEL_REASON_STATUS", tenantId]) };
+    return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["RECEIPTS_CANCEL_REASON_STATUS", tenantId] }) };
   };
 
   switch (type) {
@@ -79,4 +58,5 @@ const useReceiptsMDMS = (tenantId, type, config = {}) => {
       return null;
   }
 };
+
 export default useReceiptsMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/receipts/useReceiptsSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/receipts/useReceiptsSearch.js
@@ -1,11 +1,12 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import ReceiptsService from "../../services/elements/Receipts";
 
 export const useReceiptsSearch = (searchparams, tenantId, filters, isupdated, config = {}) => {
   const client = useQueryClient();
-  let businessService = searchparams?.businessServices;
-  const { isLoading, error, data, ...rest } = useQuery(["RECEIPTS_SEARCH", searchparams, tenantId, filters, isupdated], () => ReceiptsService.search(tenantId, filters, searchparams, businessService), config);
-  return { isLoading, error, data, revalidate: () => client.invalidateQueries(["RECEIPTS_SEARCH", searchparams, tenantId, filters, isupdated]), ...rest };
+  const businessService = searchparams?.businessServices;
+  const { isLoading, error, data, ...rest } = queryTemplate({ queryKey: ["RECEIPTS_SEARCH", searchparams, tenantId, filters, isupdated], queryFn: () => ReceiptsService.search(tenantId, filters, searchparams, businessService), config });
+  return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["RECEIPTS_SEARCH", searchparams, tenantId, filters, isupdated] }), ...rest };
 };
 
 export default useReceiptsSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/receipts/useReceiptsUpdate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/receipts/useReceiptsUpdate.js
@@ -1,8 +1,8 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ReceiptsService from "../../services/elements/Receipts";
 
 export const useReceiptsUpdate = (tenantId, businessService) => {
-  return useMutation((data) => ReceiptsService.update(data, tenantId, businessService));
+  return mutationTemplate({ mutationFn: (data) => ReceiptsService.update(data, tenantId, businessService) });
 };
 
 export default useReceiptsUpdate;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/reports/useReport.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/reports/useReport.js
@@ -1,13 +1,11 @@
 import { ReportsService } from "../../services/elements/Reports";
-import { useQuery } from "react-query";
-import React from "react";
-
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useReportMeta = {
-    fetchMetaData:(moduleName,reportName,tenantId) => 
-        useQuery(["reportMeta",moduleName,reportName],()=> ReportsService.fetchMeta({moduleName,reportName,tenantId})),
-    fetchReportData: (moduleName, reportName, tenantId,searchParams,config={}) =>
-         useQuery(["reportMetaData", moduleName, searchParams], () => ReportsService.fetchReportsData({ moduleName, reportName, tenantId,searchParams }),config)
-    
-}
-export default useReportMeta
+  fetchMetaData: (moduleName, reportName, tenantId) =>
+    queryTemplate({ queryKey: ["reportMeta", moduleName, reportName], queryFn: () => ReportsService.fetchMeta({ moduleName, reportName, tenantId }) }),
+  fetchReportData: (moduleName, reportName, tenantId, searchParams, config = {}) =>
+    queryTemplate({ queryKey: ["reportMetaData", moduleName, searchParams], queryFn: () => ReportsService.fetchReportsData({ moduleName, reportName, tenantId, searchParams }), config }),
+};
+
+export default useReportMeta;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/revalidateQuery.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/revalidateQuery.js
@@ -1,4 +1,4 @@
-import { useQueryClient } from "react-query";
+import { useQueryClient } from "../common/queryClientTemplate";
 
 export const useRevalidateQuery = async (key) => {
   const client = useQueryClient();

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/store.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/store.js
@@ -1,19 +1,16 @@
-import { useState, useEffect } from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 // import mergeConfig from "../../config/mergeConfig";
 import { StoreService } from "../services/molecules/Store/service";
 
 export const useStore = ({ stateCode, moduleCode, language }) => {
-  return useQuery(["store", stateCode, moduleCode, language], () => StoreService.defaultData(stateCode, moduleCode, language));
+  return queryTemplate({ queryKey: ["store", stateCode, moduleCode, language], queryFn: () => StoreService.defaultData(stateCode, moduleCode, language) });
 };
 
 export const useInitStore = (stateCode, enabledModules) => {
-  const { isLoading, error, isError, data } = useQuery(
-    ["initStore", stateCode, enabledModules],
-    () => StoreService.digitInitData(stateCode, enabledModules),
-    {
-      staleTime: Infinity,
-    }
-  );
+  const { isLoading, error, isError, data } = queryTemplate({
+    queryKey: ["initStore", stateCode, enabledModules],
+    queryFn: () => StoreService.digitInitData(stateCode, enabledModules),
+    config: { staleTime: Infinity },
+  });
   return { isLoading, error, isError, data };
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCfdefinitionsearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCfdefinitionsearch.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useCfdefinitionsearch = (filters, config) => {
-  return useQuery([`search_surveys`,filters.Pagination,filters.ServiceDefinitionCriteria], () => Surveys.cfdefinitionsearch(filters), { ...config });
+  return queryTemplate({ queryKey: ["search_surveys", filters.Pagination, filters.ServiceDefinitionCriteria], queryFn: () => Surveys.cfdefinitionsearch(filters), config });
 };
 
 export default useCfdefinitionsearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCfdefinitionsearchresult.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCfdefinitionsearchresult.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useCfdefinitionsearchresult = (filters, config) => {
-  return useQuery(`useCfdefinitionsearchresult_search_surveys_${new Date()}`, () => Surveys.cfdefinitionsearch(filters), { ...config });
+  return queryTemplate({ queryKey: [`useCfdefinitionsearchresult_search_surveys_${new Date()}`], queryFn: () => Surveys.cfdefinitionsearch(filters), config });
 };
 
 export default useCfdefinitionsearchresult;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCreate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCreate.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useCreateSurveys = (filters, config) => {
-  return useMutation((filters) => Surveys.create(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.create(filters) });
 };
 
 export default useCreateSurveys;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCreateSurvey.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useCreateSurvey.js
@@ -1,10 +1,9 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useCreateSurveysDef = (filters, config) => {
   console.log("useCreateSurveysDef");
-
-  return useMutation((filters) => Surveys.createSurvey(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.createSurvey(filters) });
 };
 
 export default useCreateSurveysDef;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useDelete.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useDelete.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useDeleteSurveys = (filters, config) => {
-  return useMutation((filters) => Surveys.delete(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.delete(filters) });
 };
 
 export default useDeleteSurveys;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSearch.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useSearch = (filters, config) => {
-  return useQuery(["search_surveys", filters?.uuid, filters?.title, filters?.tenantIds, filters?.postedBy, filters?.offset, filters?.limit], () => Surveys.search(filters), { ...config });
+  return queryTemplate({ queryKey: ["search_surveys", filters?.uuid, filters?.title, filters?.tenantIds, filters?.postedBy, filters?.offset, filters?.limit], queryFn: () => Surveys.search(filters), config });
 };
 
 export default useSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSelectedSurveySearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSelectedSurveySearch.js
@@ -1,9 +1,9 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useSelectedSurveySearch = (filters, config) => {
-    console.log(config,"useSelectedSurveySearch")
-  return useQuery(`search_selected_survey_${new Date()}`, () => Surveys.selectedSurveySearch(filters), { ...config });
+  console.log(config, "useSelectedSurveySearch");
+  return queryTemplate({ queryKey: [`search_selected_survey_${new Date()}`], queryFn: () => Surveys.selectedSurveySearch(filters), config });
 };
 
 export default useSelectedSurveySearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useShowResults.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useShowResults.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useShowResults = (filters, config) => {
-  return useMutation((filters) => Surveys.showResults(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.showResults(filters) });
 };
 
 export default useShowResults;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSubmitResponse.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSubmitResponse.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useSubmitResponse = (filters, config) => {
-    return useMutation((filters) => Surveys.submitResponse(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.submitResponse(filters) });
 };
 
 export default useSubmitResponse;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSubmitSurveyResponse.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSubmitSurveyResponse.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useSubmitSurveyResponse = (filters, config) => {
-    return useMutation((filters) => Surveys.submitSurveyResponse(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.submitSurveyResponse(filters) });
 };
 
 export default useSubmitSurveyResponse;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSurveyInbox.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSurveyInbox.js
@@ -1,33 +1,28 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation, useQuery } from "react-query";
-/* import { isObject, isObjectLike } from "lodash"; */
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useSearch = (filters, config) => {
-    const { filterForm, searchForm, tableForm } = filters
-    const { status } = filterForm
-    const { title, tenantIds, postedBy } = searchForm
-    const { sortBy, limit, offset, sortOrder } = tableForm;
-    const validTenantId = typeof tenantIds === 'object' ? tenantIds.code : tenantIds;
-    const validStatus = typeof status === 'object' ? status.code : status;
+  const { filterForm, searchForm, tableForm } = filters;
+  const { status } = filterForm;
+  const { title, tenantIds, postedBy } = searchForm;
+  const { sortBy, limit, offset, sortOrder } = tableForm;
+  const validTenantId = typeof tenantIds === "object" ? tenantIds.code : tenantIds;
+  const validStatus = typeof status === "object" ? status.code : status;
 
-    const finalFilters = {
-        tenantIds: validTenantId,
-        status: validStatus === "ALL" ? "" : validStatus,
-        title,
-        postedBy,
-        limit,
-        offset
-    }
+  const finalFilters = {
+    tenantIds: validTenantId,
+    status: validStatus === "ALL" ? "" : validStatus,
+    title,
+    postedBy,
+    limit,
+    offset,
+  };
 
-    //clearing out empty string params from payload
-    Object.keys(finalFilters).forEach(key => {
-        if (finalFilters[key] === '') {
-            delete finalFilters[key];
-        }
-    });
+  Object.keys(finalFilters).forEach((key) => {
+    if (finalFilters[key] === "") delete finalFilters[key];
+  });
 
-
-    return useQuery(["search_surveys", title, tenantIds, postedBy, status, offset, limit], () => Surveys.search(finalFilters), { ...config, refetchInterval: 6000 });
+  return queryTemplate({ queryKey: ["search_surveys", title, tenantIds, postedBy, status, offset, limit], queryFn: () => Surveys.search(finalFilters), config: { ...config, refetchInterval: 6000 } });
 };
 
 export default useSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSurveyUpdate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useSurveyUpdate.js
@@ -1,9 +1,9 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useUpdateSurvey = (filters, config) => {
-  console.log("updateSurvey")
-  return useMutation((filters) => Surveys.updateSurvey(filters));
+  console.log("updateSurvey");
+  return mutationTemplate({ mutationFn: (filters) => Surveys.updateSurvey(filters) });
 };
 
 export default useUpdateSurvey;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useUpdate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/surveys/useUpdate.js
@@ -1,8 +1,8 @@
 import { Surveys } from "../../services/elements/Surveys";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useUpdateSurvey = (filters, config) => {
-  return useMutation((filters) => Surveys.update(filters));
+  return mutationTemplate({ mutationFn: (filters) => Surveys.update(filters) });
 };
 
 export default useUpdateSurvey;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSVApplicationAction.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSVApplicationAction.js
@@ -1,10 +1,11 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActionsSV from "../../services/molecules/SV/ApplicationUpdateActionsSV";
 
 /** The following function is used for the mutation function */
 
 const useSVApplicationAction = (tenantId) => {
-  return useMutation((applicationData) => ApplicationUpdateActionsSV(applicationData, tenantId));
+  const mutationFn = (applicationData) => ApplicationUpdateActionsSV(applicationData, tenantId);
+  return mutationTemplate({ mutationFn });
 };
 
 export default useSVApplicationAction;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSVApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSVApplicationDetail.js
@@ -1,30 +1,26 @@
- /* 
+/*
  * hook to structure the data of applicationDetails page for a single application
- * Uses the SVSearch page where the data is strtured and returned here
+ * Uses the SVSearch page where the data is structured and returned here
  */
 
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { SVSearch } from "../../services/molecules/SV/Search";
 
-const useSVApplicationDetail = (t, tenantId, applicationNumber, isDraftApplication,config = {}, userType, args) => {
-  
+const useSVApplicationDetail = (t, tenantId, applicationNumber, isDraftApplication, config = {}, userType, args) => {
   const defaultSelect = (data) => {
-     let applicationDetails = data.applicationDetails.map((obj) => {
-      return obj;
-    });
-    
+    let applicationDetails = data.applicationDetails.map((obj) => obj);
     return {
-      applicationData : data,
-      applicationDetails
-    }
+      applicationData: data,
+      applicationDetails,
+    };
   };
 
-  return useQuery(
-    ["APPLICATION_SEARCH", "SV_SEARCH", applicationNumber,isDraftApplication, userType, args],
-    () => SVSearch.applicationDetails(t, tenantId, applicationNumber,isDraftApplication, userType, args),
-    { select: defaultSelect, ...config }
- 
-  );
+  return queryTemplate({
+    queryKey: ["APPLICATION_SEARCH", "SV_SEARCH", applicationNumber, isDraftApplication, userType, args],
+    queryFn: () => SVSearch.applicationDetails(t, tenantId, applicationNumber, isDraftApplication, userType, args),
+    select: defaultSelect,
+    config,
+  });
 };
 
 export default useSVApplicationDetail;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSVDoc.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSVDoc.js
@@ -1,20 +1,18 @@
 import { MdmsService } from "../../services/elements/MDMS";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useSVDoc = (tenantId, moduleCode, type, config = {}) => {
-  
   const useSVDocumentsRequiredScreen = () => {
-    return useQuery("SV_DOCUMENT_REQ_SCREEN", () => MdmsService.getSVDocuments(tenantId, moduleCode), config);
+    return queryTemplate({ queryKey: ["SV_DOCUMENT_REQ_SCREEN"], queryFn: () => MdmsService.getSVDocuments(tenantId, moduleCode), config });
   };
+
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {
-    
     case "Documents":
       return useSVDocumentsRequiredScreen();
-    
     default:
       return _default();
   }

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSvCreateApi.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSvCreateApi.js
@@ -1,17 +1,16 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import { SVService } from "../../services/elements/SV";
 
 /**
- * Custom hook for create API for street vending
- It takes a tenantId and an optional type parameter. If type is true, it returns a mutation function 
- that calls the SVService.create method with the provided data and tenantId.
-*/
+ * Custom hook for create API for street vending.
+ * If type is true, calls SVService.create; otherwise SVService.update.
+ */
 
 export const useSvCreateApi = (tenantId, type = true) => {
   if (type) {
-    return useMutation((data) => SVService.create(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => SVService.create(data, tenantId) });
   } else {
-    return useMutation((data) => SVService.update(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => SVService.update(data, tenantId) });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSvSearchApplication.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/sv/useSvSearchApplication.js
@@ -2,24 +2,21 @@
  * Following hook is used to get data of applications from backend in Street Vending module and returns the data in an object "SVDetail"
  */
 
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
-const useSvSearchApplication = ({ tenantId, filters, auth,searchedFrom="" }, config = {}) => {
+const useSvSearchApplication = ({ tenantId, filters, auth, searchedFrom = "" }, config = {}) => {
   const client = useQueryClient();
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
 
-  // Selects the data to be returned by the hook
   const defaultSelect = (data) => {
-    if(data.SVDetail.length > 0)  data.SVDetail[0].applicationNo = data.SVDetail[0].applicationNo || [];
+    if (data.SVDetail.length > 0) data.SVDetail[0].applicationNo = data.SVDetail[0].applicationNo || [];
     return data;
   };
 
-  const { isLoading, error, data, isSuccess } = useQuery(["streetVendingSearchList", tenantId, filters, auth, config], () => Digit.SVService.search(args), {
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ["streetVendingSearchList", tenantId, filters, auth, config], queryFn: () => Digit.SVService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries(["streetVendingSearchList", tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: ["streetVendingSearchList", tenantId, filters, auth] }) };
 };
 
 export default useSvSearchApplication;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useApplicationActions.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useApplicationActions.js
@@ -1,8 +1,9 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActions from "../../services/molecules/TL/ApplicationUpdateActions";
 
 const useApplicationActions = (tenantId) => {
-  return useMutation((applicationData) => ApplicationUpdateActions(applicationData, tenantId));
+  const mutationFn = (applicationData) => ApplicationUpdateActions(applicationData, tenantId);
+  return mutationTemplate({ mutationFn });
 };
 
 export default useApplicationActions;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useApplicationDetail.js
@@ -1,13 +1,13 @@
 import { TLSearch } from "../../services/molecules/TL/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useApplicationDetail = (t, tenantId, applicationNumber, config = {}, userType) => {
-  let EditRenewalApplastModifiedTime = Digit.SessionStorage.get("EditRenewalApplastModifiedTime");
-  return useQuery(
-    ["APPLICATION_SEARCH", "TL_SEARCH", applicationNumber, userType, EditRenewalApplastModifiedTime],
-    () => TLSearch.applicationDetails(t, tenantId, applicationNumber, userType),
-    config
-  );
+  const EditRenewalApplastModifiedTime = Digit.SessionStorage.get("EditRenewalApplastModifiedTime");
+  return queryTemplate({
+    queryKey: ["APPLICATION_SEARCH", "TL_SEARCH", applicationNumber, userType, EditRenewalApplastModifiedTime],
+    queryFn: () => TLSearch.applicationDetails(t, tenantId, applicationNumber, userType),
+    config,
+  });
 };
 
 export default useApplicationDetail;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useMDMS.js
@@ -1,66 +1,46 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const useMDMS = {
   applicationTypes: (tenantId) =>
-    useQuery(
-      [tenantId, "TL_MDMS_APPLICATION_STATUS"],
-      () =>
-      MdmsServiceV2.getDataByCriteria(
+    queryTemplate({
+      queryKey: [tenantId, "TL_MDMS_APPLICATION_STATUS"],
+      queryFn: () =>
+        MdmsServiceV2.getDataByCriteria(
           tenantId,
           {
             details: {
-              tenantId: tenantId,
-              moduleDetails: [
-                {
-                  moduleName: "TradeLicense",
-                  masterDetails: [
-                    {
-                      name: "ApplicationType",
-                    },
-                  ],
-                },
-              ],
+              tenantId,
+              moduleDetails: [{ moduleName: "TradeLicense", masterDetails: [{ name: "ApplicationType" }] }],
             },
           },
           "TL"
         ),
-      {
-        select: (data) =>
-          data.TradeLicense.ApplicationType?.map((type) => ({
-            code: type.code.split(".")[1],
-            i18nKey: `TL_APPLICATIONTYPE.${type.code.split(".")[1]}`,
-          })),
-      }
-    ),
+      select: (data) =>
+        data.TradeLicense.ApplicationType?.map((type) => ({
+          code: type.code.split(".")[1],
+          i18nKey: `TL_APPLICATIONTYPE.${type.code.split(".")[1]}`,
+        })),
+    }),
 
   getFormConfig: (tenantId, config) =>
-    useQuery(
-      [tenantId, "FORM_CONFIG"],
-      () =>
-      MdmsService.getDataByCriteria(
+    queryTemplate({
+      queryKey: [tenantId, "FORM_CONFIG"],
+      queryFn: () =>
+        MdmsService.getDataByCriteria(
           tenantId,
           {
             details: {
-              tenantId: tenantId,
-              moduleDetails: [
-                {
-                  moduleName: "TradeLicense",
-                  masterDetails: [
-                    {
-                      name: "CommonFieldsConfig",
-                    },
-                  ],
-                },
-              ],
+              tenantId,
+              moduleDetails: [{ moduleName: "TradeLicense", masterDetails: [{ name: "CommonFieldsConfig" }] }],
             },
           },
           "TL"
         ),
-      { select: (d) => d.TradeLicense.CommonFieldsConfig, ...config }
-    ),
+      select: (d) => d.TradeLicense.CommonFieldsConfig,
+      config,
+    }),
 };
 
 export default useMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useSearch.js
@@ -1,15 +1,11 @@
-import React from "react";
-import { useQuery } from "react-query";
-import { TLService } from "../../services/elements/TL"
+import { queryTemplate } from "../../common/queryTemplate";
+import { TLService } from "../../services/elements/TL";
 
-const useSearch = ({tenantId, filters, config={}}) => useQuery(
-    ["TL_SEARCH", tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
-    () => TLService.TLsearch({tenantId, filters}),
-    {
-        // select: (data) => data.Licenses,
-        ...config
-    }
- )
+const useSearch = ({ tenantId, filters, config = {} }) =>
+  queryTemplate({
+    queryKey: ["TL_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e])],
+    queryFn: () => TLService.TLsearch({ tenantId, filters }),
+    config,
+  });
 
-
-export default useSearch
+export default useSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLDocumentSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLDocumentSearch.js
@@ -1,23 +1,20 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useTLDocumentSearch = (data1 = {}, config = {}) => {
   const client = useQueryClient();
-  const tenantId = Digit.ULBService.getCurrentTenantId();
   const tenant = Digit.ULBService.getStateId();
-  //const propertyId = property?.propertyId;
-  //const filesArray = property?.documents?.map((value) => value?.fileStoreId);
-  let filesArray = window.location.href.includes("/tl/tradelicence/application/") ?  data1?.value?.tradeLicenseDetail?.applicationDocuments.map(ob => ob?.fileStoreId) : [];
-  if(data1?.value?.workflowDocs) filesArray = data1?.value?.workflowDocs?.map(ob => ob?.fileStoreId)
+
+  let filesArray = window.location.href.includes("/tl/tradelicence/application/")
+    ? data1?.value?.tradeLicenseDetail?.applicationDocuments.map((ob) => ob?.fileStoreId)
+    : [];
+  if (data1?.value?.workflowDocs) filesArray = data1?.value?.workflowDocs?.map((ob) => ob?.fileStoreId);
   if (data1?.value?.owners?.documents["OwnerPhotoProof"]?.fileStoreId) filesArray.push(data1.value.owners.documents["OwnerPhotoProof"].fileStoreId);
   if (data1?.value?.owners?.documents["ProofOfIdentity"]?.fileStoreId) filesArray.push(data1.value.owners.documents["ProofOfIdentity"].fileStoreId);
   if (data1?.value?.owners?.documents["ProofOfOwnership"]?.fileStoreId) filesArray.push(data1.value.owners.documents["ProofOfOwnership"].fileStoreId);
-  // let filesArray = [
-  //   data1.value.owners.documents["OwnerPhotoProof"].fileStoreId,
-  //   data1.value.owners.documents["ProofOfIdentity"].fileStoreId,
-  //   data1.value.owners.documents["ProofOfOwnership"].fileStoreId,
-  // ];
-  const { isLoading, error, data } = useQuery([`tlDocuments-${1}`, filesArray], () => Digit.UploadServices.Filefetch(filesArray, tenant));
-  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries([`tlDocuments-${1}`, filesArray]) };
+
+  const { isLoading, error, data } = queryTemplate({ queryKey: [`tlDocuments-${1}`, filesArray], queryFn: () => Digit.UploadServices.Filefetch(filesArray, tenant) });
+  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries({ queryKey: [`tlDocuments-${1}`, filesArray] }) };
 };
 
 export default useTLDocumentSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLGenderMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLGenderMDMS.js
@@ -1,12 +1,10 @@
-import { useQuery } from "react-query";
-import { MdmsService } from "../../services/elements/MDMS";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
 
 const useTLGenderMDMS = (tenantId, moduleCode, type, config = {}) => {
   const useTLGenders = () => {
-    return useQuery("TL_GENDER_DETAILS", () => MdmsServiceV2.TLGenderType(tenantId, moduleCode ,type), config);
+    return queryTemplate({ queryKey: ["TL_GENDER_DETAILS"], queryFn: () => MdmsServiceV2.TLGenderType(tenantId, moduleCode, type), config });
   };
-  
 
   switch (type) {
     case "GenderType":
@@ -15,7 +13,5 @@ const useTLGenderMDMS = (tenantId, moduleCode, type, config = {}) => {
       return null;
   }
 };
-
-
 
 export default useTLGenderMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLWorkflowData.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLWorkflowData.js
@@ -1,13 +1,12 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WorkflowService } from "../../services/elements/WorkFlow";
 
-const useTLWorkflowData = ({tenantId, filters, config={}}) => {
-    return useQuery(["WORKFLOW_BY_GET_ALL_APPLICATION", tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )], () => WorkflowService.getAllApplication(tenantId, filters),
-    {
-        ...config
-    });
+const useTLWorkflowData = ({ tenantId, filters, config = {} }) => {
+  return queryTemplate({
+    queryKey: ["WORKFLOW_BY_GET_ALL_APPLICATION", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e])],
+    queryFn: () => WorkflowService.getAllApplication(tenantId, filters),
+    config,
+  });
 };
 
-
-export default useTLWorkflowData
+export default useTLWorkflowData;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLsearchApplication.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTLsearchApplication.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const mapWfBybusinessId = (workflowData) => {
   return workflowData?.reduce((acc, item) => {
@@ -32,50 +33,41 @@ export const useTLSearchApplication = (params, config = {}, t) => {
   const client = useQueryClient();
   let multiownername = "";
   params.tenantId = Digit.ULBService.getCitizenCurrentTenant();
-  const result = useQuery(["TL_APPLICATIONS_LIST", params], useTLSearch(params, config), {
-    staleTime: Infinity,
-    select: (data) => {
-      return data?.map((i) => ({
+  const result = queryTemplate({
+    queryKey: ["TL_APPLICATIONS_LIST", params],
+    queryFn: useTLSearch(params, config),
+    select: (data) =>
+      data?.map((i) => ({
         TL_COMMON_TABLE_COL_APP_NO: i.applicationNumber,
         TL_APPLICATION_CATEGORY: "ACTION_TEST_TRADE_LICENSE",
         TL_COMMON_TABLE_COL_OWN_NAME: i?.tradeLicenseDetail?.subOwnerShipCategory.includes("INSTITUTION")
           ? i?.tradeLicenseDetail?.institution?.name
-          : i?.tradeLicenseDetail?.owners!==null ? i?.tradeLicenseDetail?.owners.sort((a,b)=>a?.additionalDetails?.ownerSequence-b?.additionalDetails?.ownerSequence)?.map((ele, index) =>
+          : i?.tradeLicenseDetail?.owners !== null
+          ? i?.tradeLicenseDetail?.owners
+              .sort((a, b) => a?.additionalDetails?.ownerSequence - b?.additionalDetails?.ownerSequence)
+              ?.map((ele, index) => (index == 0 ? (multiownername = ele.name) : (multiownername = multiownername + " , " + ele.name)))
+          : i?.tradeLicenseDetail?.owners?.map((ele, index) =>
               index == 0 ? (multiownername = ele.name) : (multiownername = multiownername + " , " + ele.name)
-            ) : i?.tradeLicenseDetail?.owners?.map((ele, index) =>
-            index == 0 ? (multiownername = ele.name) : (multiownername = multiownername + " , " + ele.name)
-          ),
+            ),
         TL_COMMON_TABLE_COL_STATUS: `WF_NEWTL_${i?.status}`,
-        TL_COMMON_TABLE_COL_SLA_NAME: i?.status.match(/^(EXPIRED|APPROVED|CANCELLED)$/)? "CS_NA" : `${Math.round(i?.SLA / (1000 * 60 * 60 * 24))} ${t("TL_SLA_DAYS")}`,
+        TL_COMMON_TABLE_COL_SLA_NAME: i?.status.match(/^(EXPIRED|APPROVED|CANCELLED)$/) ? "CS_NA" : `${Math.round(i?.SLA / (1000 * 60 * 60 * 24))} ${t("TL_SLA_DAYS")}`,
         TL_COMMON_TABLE_COL_TRD_NAME: i?.tradeName,
-        TL_INSTITUTION_TYPE_LABEL: i?.tradeLicenseDetail?.subOwnerShipCategory.includes("INSTITUTION")
-          ? `TL_${i?.tradeLicenseDetail?.subOwnerShipCategory}`
-          : null,
+        TL_INSTITUTION_TYPE_LABEL: i?.tradeLicenseDetail?.subOwnerShipCategory.includes("INSTITUTION") ? `TL_${i?.tradeLicenseDetail?.subOwnerShipCategory}` : null,
         raw: i,
-      }));
-    },
+      })),
+    config: { staleTime: Infinity },
   });
-  return { ...result, revalidate: () => client.invalidateQueries(["TL_APPLICATIONS_LIST", params]) };
+  return { ...result, revalidate: () => client.invalidateQueries({ queryKey: ["TL_APPLICATIONS_LIST", params] }) };
 };
 
 export const useTLApplicationDetails = (params, config) => {
   const client = useQueryClient();
-  const result = useQuery(["TL_APPLICATION_DETAILS", params], useTLSearch(params, config), {
-    staleTime: Infinity,
-    // select: (data) => {
-    //   return data.map(i => ({
-    //     TL_COMMON_TABLE_COL_APP_NO: i.applicationNumber,
-    //     TL_APPLICATION_CATEGORY: "ACTION_TEST_TRADE_LICENSE",
-    //     TL_COMMON_TABLE_COL_OWN_NAME: i?.tradeLicenseDetail?.owners?.map((ele) => ele?.name),
-    //     TL_COMMON_TABLE_COL_STATUS: `WF_NEWTL_${i?.status}`,
-    //     TL_COMMON_TABLE_COL_SLA_NAME: `${i?.SLA / (1000 * 60 * 60 * 24)} Days`,
-    //     TL_COMMON_TABLE_COL_TRD_NAME: i?.tradeName,
-    //     TL_COMMON_CITY_NAME: i.tenantId,
-    //     raw: i
-    //   }))
-    // }
+  const result = queryTemplate({
+    queryKey: ["TL_APPLICATION_DETAILS", params],
+    queryFn: useTLSearch(params, config),
+    config: { staleTime: Infinity },
   });
-  return { ...result, revalidate: () => client.invalidateQueries(["TL_APPLICATION_DETAILS", params]) };
+  return { ...result, revalidate: () => client.invalidateQueries({ queryKey: ["TL_APPLICATION_DETAILS", params] }) };
 };
 
 export default useTLSearchApplication;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseAPI.js
@@ -1,12 +1,12 @@
 import { TLService } from "../../services/elements/TL";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useTradeLicenseAPI = (tenantId, type = true) => {
-  if(type){
-  return useMutation((data) => TLService.create(data, tenantId));
-} else {
-  return useMutation((data) => TLService.update(data, tenantId));
-}
+  if (type) {
+    return mutationTemplate({ mutationFn: (data) => TLService.create(data, tenantId) });
+  } else {
+    return mutationTemplate({ mutationFn: (data) => TLService.update(data, tenantId) });
+  }
 };
 
 export default useTradeLicenseAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseBillingslab.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseBillingslab.js
@@ -1,11 +1,11 @@
-import { useQuery, useQueryClient } from "react-query";
-
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useTradeLicenseBillingslab = ({ tenantId, filters, auth }, config = {}) => {
-    const client = useQueryClient();
-    const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
-    const { isLoading, error, data } = useQuery(["TLbillingSlabSerach", tenantId, filters], () => Digit.TLService.billingslab(args), config);
-    return { isLoading, error, data, revalidate: () => client.invalidateQueries(["TLbillingSlabSerach", tenantId, filters]) };
+  const client = useQueryClient();
+  const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
+  const { isLoading, error, data } = queryTemplate({ queryKey: ["TLbillingSlabSerach", tenantId, filters], queryFn: () => Digit.TLService.billingslab(args), config });
+  return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["TLbillingSlabSerach", tenantId, filters] }) };
 };
 
 export default useTradeLicenseBillingslab;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseMDMS.js
@@ -1,106 +1,94 @@
 import { MdmsServiceV2 } from "../../services/elements/MDMSV2";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useTradeLicenseMDMS = (tenantId, moduleCode, type, filter, config = {}) => {
   const useTLDocuments = () => {
-    return useQuery("TL_DOCUMENTS", () => MdmsServiceV2.getTLDocumentRequiredScreen(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["TL_DOCUMENTS"], queryFn: () => MdmsServiceV2.getTLDocumentRequiredScreen(tenantId, moduleCode, type), config });
   };
   const useStructureType = () => {
-    return useQuery("TL_STRUCTURE_TYPE", () => MdmsServiceV2.getTLStructureType(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["TL_STRUCTURE_TYPE"], queryFn: () => MdmsServiceV2.getTLStructureType(tenantId, moduleCode, type), config });
   };
   const useTradeUnitsData = () => {
-    return useQuery("TL_TRADE_UNITS", () => MdmsServiceV2.getTradeUnitsData(tenantId, moduleCode, type, filter), config);
+    return queryTemplate({ queryKey: ["TL_TRADE_UNITS"], queryFn: () => MdmsServiceV2.getTradeUnitsData(tenantId, moduleCode, type, filter), config });
   };
   const useTradeOwnerShipCategory = () => {
-    return useQuery("TL_TRADE_OWNERSHIP_CATEGORY", () => MdmsServiceV2.GetTradeOwnerShipCategory(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["TL_TRADE_OWNERSHIP_CATEGORY"], queryFn: () => MdmsServiceV2.GetTradeOwnerShipCategory(tenantId, moduleCode, type), config });
   };
   const useTradeOwnershipSubType = () => {
-    return useQuery("TL_TRADE_OWNERSHIP_CATEGORY", () => MdmsServiceV2.GetTradeOwnerShipCategory(tenantId, moduleCode, type), {
-      select: data => {
-        const {"common-masters":{OwnerShipCategory: categoryData} ={}} = data
-        const filteredSubtypesData = categoryData.filter( e => e.code.includes(filter.keyToSearchOwnershipSubtype)).map( e => ({...e, i18nKey: `COMMON_MASTERS_OWNERSHIPCATEGORY_${e.code.replaceAll(".", "_")}`}))
-        return filteredSubtypesData
+    return queryTemplate({
+      queryKey: ["TL_TRADE_OWNERSHIP_CATEGORY"],
+      queryFn: () => MdmsServiceV2.GetTradeOwnerShipCategory(tenantId, moduleCode, type),
+      select: (data) => {
+        const { "common-masters": { OwnerShipCategory: categoryData } = {} } = data;
+        return categoryData.filter((e) => e.code.includes(filter.keyToSearchOwnershipSubtype)).map((e) => ({ ...e, i18nKey: `COMMON_MASTERS_OWNERSHIPCATEGORY_${e.code.replaceAll(".", "_")}` }));
       },
-      ...config
+      config,
     });
   };
-
   const useOwnerTypeWithSubtypes = () => {
-    return useQuery("TL_TRADE_OWNERSSHIP_TYPE", () => MdmsServiceV2.GetTradeOwnerShipCategory(tenantId, moduleCode, type), {
-      select: data => {
-        const {"common-masters":{OwnerShipCategory: categoryData} ={}} = data
+    return queryTemplate({
+      queryKey: ["TL_TRADE_OWNERSSHIP_TYPE"],
+      queryFn: () => MdmsServiceV2.GetTradeOwnerShipCategory(tenantId, moduleCode, type),
+      select: (data) => {
+        const { "common-masters": { OwnerShipCategory: categoryData } = {} } = data;
         let OwnerShipCategory = {};
         let ownerShipdropDown = [];
-        
+
         function getDropdwonForProperty(ownerShipdropDown) {
           if (filter?.userType === "employee") {
             const arr = ownerShipdropDown
               ?.filter((e) => e.code.split(".").length <= 2)
               ?.map((ownerShipDetails) => ({
                 ...ownerShipDetails,
-                i18nKey: `COMMON_MASTERS_OWNERSHIPCATEGORY_INDIVIDUAL_${
-                  ownerShipDetails.value.split(".")[1] ? ownerShipDetails.value.split(".")[1] : ownerShipDetails.value.split(".")[0]
-                }`,
+                i18nKey: `COMMON_MASTERS_OWNERSHIPCATEGORY_INDIVIDUAL_${ownerShipDetails.value.split(".")[1] ? ownerShipDetails.value.split(".")[1] : ownerShipDetails.value.split(".")[0]}`,
               }));
-              const finalArr = arr.filter(data => data.code.includes("INDIVIDUAL") || data.code.includes("OTHER"))
-      
-            return finalArr;
+            return arr.filter((data) => data.code.includes("INDIVIDUAL") || data.code.includes("OTHER"));
           }
-      
-          const res = ownerShipdropDown?.length ? ownerShipdropDown?.map((ownerShipDetails) => ({
-                ...ownerShipDetails,
-                i18nKey: `PT_OWNERSHIP_${
-                  ownerShipDetails.value.split(".")[1] ? ownerShipDetails.value.split(".")[1] : ownerShipDetails.value.split(".")[0]
-                }`,
-              })).reduce((acc, ownerShipDetails) => {
-                if(ownerShipDetails.code.includes("INDIVIDUAL")){
-                  return [...acc, ownerShipDetails]
-                } else if (ownerShipDetails.code.includes("OTHER")) {
-                  const { code, value, ...everythingElse } = ownerShipDetails
-                  const mutatedOwnershipDetails =  { code: code.split(".")[0], value: value.split(".")[0], ...everythingElse }
-                  return [...acc, mutatedOwnershipDetails]
-                } else {
-                  return acc
-                }
-              },[]) : null
-              
-          return res
+          const res = ownerShipdropDown?.length
+            ? ownerShipdropDown
+                ?.map((ownerShipDetails) => ({
+                  ...ownerShipDetails,
+                  i18nKey: `PT_OWNERSHIP_${ownerShipDetails.value.split(".")[1] ? ownerShipDetails.value.split(".")[1] : ownerShipDetails.value.split(".")[0]}`,
+                }))
+                .reduce((acc, ownerShipDetails) => {
+                  if (ownerShipDetails.code.includes("INDIVIDUAL")) {
+                    return [...acc, ownerShipDetails];
+                  } else if (ownerShipDetails.code.includes("OTHER")) {
+                    const { code, value, ...everythingElse } = ownerShipDetails;
+                    return [...acc, { code: code.split(".")[0], value: value.split(".")[0], ...everythingElse }];
+                  } else {
+                    return acc;
+                  }
+                }, [])
+            : null;
+          return res;
         }
 
         function formDropdown(category) {
-          const { name, code } = category;
-          return {
-            label: name,
-            value: code,
-            code: code,
-          };
+          return { label: category.name, value: category.code, code: category.code };
         }
 
-        categoryData.length > 0 ? categoryData?.map((category) => {
-          OwnerShipCategory[category.code] = category;
-        }) : null
+        categoryData.length > 0 ? categoryData?.map((category) => { OwnerShipCategory[category.code] = category; }) : null;
 
         if (OwnerShipCategory) {
           Object.keys(OwnerShipCategory)?.forEach((category) => {
-            // const categoryCode = OwnerShipCategory[category].code;
             ownerShipdropDown.push(formDropdown(OwnerShipCategory[category]));
           });
         }
-        
+
         return getDropdwonForProperty(ownerShipdropDown);
-    
       },
-      ...config
+      config,
     });
   };
   const useTLAccessoriesType = () => {
-    return useQuery("TL_TRADE_ACCESSORY_CATEGORY", () => MdmsServiceV2.getTLAccessoriesType(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["TL_TRADE_ACCESSORY_CATEGORY"], queryFn: () => MdmsServiceV2.getTLAccessoriesType(tenantId, moduleCode, type), config });
   };
   const useTLFinancialYear = () => {
-    return useQuery("TL_TRADE_FINANCIAL_YEAR", () => MdmsServiceV2.getTLFinancialYear(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["TL_TRADE_FINANCIAL_YEAR"], queryFn: () => MdmsServiceV2.getTLFinancialYear(tenantId, moduleCode, type), config });
   };
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsServiceV2.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsServiceV2.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/useTradeLicenseSearch.js
@@ -1,22 +1,18 @@
 import { useEffect } from "react";
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useTradeLicenseSearch = ({ tenantId, filters, auth }, config = {}) => {
   const client = useQueryClient();
-
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
-  const { isLoading, error, data } = useQuery(["tradeSearchList", tenantId, filters], () => Digit.TLService.TLsearch(args), config);
-  useEffect (() => {
-    if(config?.filters?.tenantId)
-    Digit.LocalizationService.getLocale({modules: [`rainmaker-${config.filters?.tenantId}`], locale: Digit.StoreData.getCurrentLanguage(), tenantId: `${config?.filters?.tenantId}`});
-  },[config?.filters?.tenantId]);
-//   if (!isLoading && data && data?.Properties && Array.isArray(data.Properties) && data.Properties.length > 0) {
-//     data.Properties[0].units = data.Properties[0].units || [];
-//     data.Properties[0].units = data.Properties[0].units.filter((unit) => unit.active);
-//     data.Properties[0].owners = data.Properties[0].owners || [];
-//     data.Properties[0].owners = data.Properties[0].owners.filter((owner) => owner.status === "ACTIVE");
-//   }
-  return { isLoading, error, data, revalidate: () => client.invalidateQueries(["tradeSearchList", tenantId, filters]) };
+  const { isLoading, error, data } = queryTemplate({ queryKey: ["tradeSearchList", tenantId, filters], queryFn: () => Digit.TLService.TLsearch(args), config });
+
+  useEffect(() => {
+    if (config?.filters?.tenantId)
+      Digit.LocalizationService.getLocale({ modules: [`rainmaker-${config.filters?.tenantId}`], locale: Digit.StoreData.getCurrentLanguage(), tenantId: `${config?.filters?.tenantId}` });
+  }, [config?.filters?.tenantId]);
+
+  return { isLoading, error, data, revalidate: () => client.invalidateQueries({ queryKey: ["tradeSearchList", tenantId, filters] }) };
 };
 
 export default useTradeLicenseSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/userPaymentHistory.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/tl/userPaymentHistory.js
@@ -1,8 +1,8 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { PaymentService } from "../../services/elements/Payment";
 
 const useTLPaymentHistory = (tenantId, id, config = {}) => {
-  return useQuery(["PAYMENT_HISTORY", id], () => PaymentService.getReciept(tenantId, "TL", { consumerCodes: id }), { ...config });
+  return queryTemplate({ queryKey: ["PAYMENT_HISTORY", id], queryFn: () => PaymentService.getReciept(tenantId, "TL", { consumerCodes: id }), config });
 };
 
 export default useTLPaymentHistory;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useAccessControl.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useAccessControl.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import AccessControlService from "../services/elements/Access";
 const useAccessControl = (tenantId) => {
   const getUserRoles = Digit.SessionStorage.get("User")?.info?.roles;
@@ -7,7 +7,7 @@ const useAccessControl = (tenantId) => {
     return role.code;
   });
 
-  const response = useQuery(["ACCESS_CONTROL", tenantId], async () => await AccessControlService.getAccessControl(roles),{enabled:roles?true:false});
+  const response = queryTemplate({ queryKey: ["ACCESS_CONTROL", tenantId], queryFn: async () => await AccessControlService.getAccessControl(roles), config: {enabled:roles?true:false} });
   return response;
 };
 export default useAccessControl;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useApplicationForBillSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useApplicationForBillSearch.js
@@ -1,6 +1,6 @@
 import { FSMService } from "../services/elements/FSM";
 import { PTService } from "../services/elements/PT";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { MCollectService } from "../services/elements/MCollect";
 import { PTRService } from "../services/elements/PTR";
 import { CHBServices } from "../services/elements/CHB";
@@ -175,9 +175,7 @@ export const useApplicationsForBusinessServiceSearch = ({ tenantId, businessServ
 
   /* key from application ie being used as consumer code in bill */
   const { searchFn, key, label } = refObj(tenantId, filters)[_key];
-  const applications = useQuery(["applicationsForBillDetails", { tenantId, businessService, filters, searchFn }], searchFn, {
-    ...config,
-  });
+  const applications = queryTemplate({ queryKey: ["applicationsForBillDetails", { tenantId, businessService, filters, searchFn }], queryFn: searchFn, config });
 
   return { ...applications, key, label };
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomAPIHook.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomAPIHook.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
+import { useQueryClient } from "../common/queryClientTemplate";
 import { CustomService } from "../services/elements/CustomService";
 
 /**
@@ -16,11 +17,11 @@ import { CustomService } from "../services/elements/CustomService";
 const useCustomAPIHook = (url, params, body, plainAccessRequest, options = {}) => {
   const client = useQueryClient();
   //api name, querystr, reqbody
-  const { isLoading, data } = useQuery(
-    ["CUSTOM", { ...params, ...body, ...plainAccessRequest }].filter((e) => e),
-    () => CustomService.getResponse({ url, params, ...body, plainAccessRequest }),
-    options
-  );
+  const { isLoading, data } = queryTemplate({
+    queryKey: ["CUSTOM", { ...params, ...body, ...plainAccessRequest }].filter((e) => e),
+    queryFn: () => CustomService.getResponse({ url, params, ...body, plainAccessRequest }),
+    config: options,
+  });
   return {
     isLoading,
     data,

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomMDMS.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { MdmsService } from "../services/elements/MDMS";
 
 /**
@@ -26,7 +26,7 @@ import { MdmsService } from "../services/elements/MDMS";
  * @returns {Object} Returns the object of the useQuery from react-query.
  */
 const useCustomMDMS = (tenantId, moduleName, masterDetails = [], config = {}) => {
-  return useQuery([tenantId, moduleName, masterDetails], () => MdmsService.getMultipleTypesWithFilter(tenantId, moduleName, masterDetails), config);
+  return queryTemplate({ queryKey: [tenantId, moduleName, masterDetails], queryFn: () => MdmsService.getMultipleTypesWithFilter(tenantId, moduleName, masterDetails), config });
 };
 
 export default useCustomMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomMDMSV2.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomMDMSV2.js
@@ -1,11 +1,10 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { MdmsServiceV2 } from "../services/elements/MDMSV2";
 
 /**
  * Custom hook which can be used to
  * make a single hook a module to get multiple masterdetails with/without filter
  * 
- * @author jagankumar-egov
  * 
  * @example
  * // returns useQuery object
@@ -26,7 +25,7 @@ import { MdmsServiceV2 } from "../services/elements/MDMSV2";
  * @returns {Object} Returns the object of the useQuery from react-query.
  */
 const useCustomMDMSV2 = (tenantId, moduleName, masterDetails = [], config = {}) => {
-    return useQuery([tenantId, moduleName, masterDetails], () => MdmsServiceV2.getMultipleTypesWithFilter(tenantId, moduleName, masterDetails), config);
+    return queryTemplate({ queryKey: [tenantId, moduleName, masterDetails], queryFn: () => MdmsServiceV2.getMultipleTypesWithFilter(tenantId, moduleName, masterDetails), config });
   };
 
 export default useCustomMDMSV2;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomNavigate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useCustomNavigate.js
@@ -1,0 +1,29 @@
+import { useNavigate } from "react-router-dom";
+
+/**
+ * Custom navigation hook that wraps react-router-dom's useNavigate
+ * This centralizes navigation logic for easier upgrades
+ * 
+ * Usage:
+ * const navigate = Digit.Hooks.useCustomNavigate();
+ * navigate("/path");
+ * navigate("/path", { state: { data } });
+ * navigate(-1); // go back
+ */
+const useCustomNavigate = () => {
+  const navigate = useNavigate();
+  
+  return (to, options = {}) => {
+    try {
+      navigate(to, options);
+    } catch (error) {
+      console.error("Navigation error:", error);
+      // Fallback for navigation failures
+      if (typeof to === "string") {
+        window.location.href = to;
+      }
+    }
+  };
+};
+
+export default useCustomNavigate;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useDocumentSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useDocumentSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
+import { useQueryClient } from "../common/queryClientTemplate";
 import PropTypes from "prop-types";
 
 
@@ -7,7 +8,7 @@ const useDocumentSearch = (documents=[], config = {}) => {
   const tenant = Digit.ULBService.getStateId();
   const filesArray = documents?.map((value) => value?.fileStoreId);
 
-  const { isLoading, error, data } = useQuery([filesArray.join('')], () => Digit.UploadServices.Filefetch(filesArray, tenant),{enabled:filesArray&&filesArray.length>0,
+  const { isLoading, error, data } = queryTemplate({ queryKey: [filesArray.join('')], queryFn: () => Digit.UploadServices.Filefetch(filesArray, tenant), config: {enabled:filesArray&&filesArray.length>0,
   /* It will return back the same document object with fileUrl link and response */
     select: (data) => {
       return documents.map(document=>{
@@ -19,8 +20,8 @@ const useDocumentSearch = (documents=[], config = {}) => {
         }
       })
     }, 
-  ...config});
-  return { isLoading, error, data: { pdfFiles: data }, revalidate: () => client.invalidateQueries([filesArray.join('')]) };
+  ...config} });
+  return { isLoading, error, data: { pdfFiles: data }, revalidate: () => client.invalidateQueries({ queryKey: [filesArray.join('')] }) };
 };
 
 /**

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useDynamicData.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useDynamicData.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { TLService } from "./../services/elements/TL";
 import { MCollectService } from "./../services/elements/MCollect";
 import { PGRService } from "../services/elements/PGR";
@@ -9,41 +9,38 @@ import { format, subMonths } from "date-fns";
 
 const useDynamicData = ({moduleCode ,tenantId, filters, t }) => {
     const useTLDynamicData = () => {
-        const { isLoading, error, data, isSuccess } =  useQuery(['TL_OPEN_SEARCH', tenantId, filters], async () => await TLService.TLOpensearch({ tenantId, filters }), 
-        {select: (data) => {
+        const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['TL_OPEN_SEARCH', tenantId, filters], queryFn: async () => await TLService.TLOpensearch({ tenantId, filters }), config: {select: (data) => {
             const tlData = {
                 dynamicDataOne : data?.applicationsIssued === 0 || data?.applicationsIssued === null ? null : data?.applicationsIssued + " " + t("APPLICATION_ISSUED_IN_LAST_12_MONTHS"),
                 dynamicDataTwo : data?.applicationsRenewed === 0 || data?.applicationsRenewed === null ? null : data?.applicationsRenewed + " " + t("APPLICATION_RENEWED_IN_LAST_12_MONTHS"),
                 staticData : data?.applicationValidity === 0 || data?.applicationValidity === null ? null :  data?.applicationValidity + " " + (data?.applicationValidity === 1 ? t("COMMON_YEAR") : t("COMMON_YEARS"))
             }
             return tlData;
-        }});
+        }}});
         return { isLoading, error, data, isSuccess };
     }
 
     const useMCOLLECTDynamicData = () => {
-        const { isLoading, error, data, isSuccess } =  useQuery(['MCOLLECT_OPEN_SEARCH', tenantId, filters], async () => await MCollectService.MCollectOpenSearch({ tenantId, filters }), 
-        {select: (data) => {
+        const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['MCOLLECT_OPEN_SEARCH', tenantId, filters], queryFn: async () => await MCollectService.MCollectOpenSearch({ tenantId, filters }), config: {select: (data) => {
             const mCollectData = {
                 dynamicDataOne : data?.countOfServices === 0 || data?.countOfServices === null ? null : data?.countOfServices + " "+ t("SERVICE_CATEGORIES_OF_CHALLANS_PROCESSED_IN") + " " + t(tenantId),
                 dynamicDataTwo : data?.totalAmountCollected === 0 || data?.totalAmountCollected === null ? null : `₹ ${data?.totalAmountCollected}` + " " +  t("COLLECTED_IN_FORM_OF_CHALLANS_IN_LAST_12_MONTHS"),
                 staticData : data?.challanValidity === 0 || data?.challanValidity === null ? null :  data?.challanValidity + " " + (data?.challanValidity === 1 ? t("COMMON_DAY") : t("COMMON_DAYS"))
             }
             return mCollectData;
-        }});
+        }}});
         return { isLoading, error, data, isSuccess };
     }
 
     const usePGRDynamicData = () => {
-        const { isLoading, error, data, isSuccess } =  useQuery(['PGR_OPEN_SEARCH', tenantId, filters], async () => await PGRService.PGROpensearch({ tenantId, filters }), 
-        {select: (data) => {
+        const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['PGR_OPEN_SEARCH', tenantId, filters], queryFn: async () => await PGRService.PGROpensearch({ tenantId, filters }), config: {select: (data) => {
             const pgrData = {
                 dynamicDataOne : data?.complaintsResolved === 0 || data?.complaintsResolved === null ? null : data?.complaintsResolved + " " + t("COMPLAINTS_RESOLVED_IN_LAST_30_DAYS"),
                 dynamicDataTwo : data?.averageResolutionTime === 0 || data?.averageResolutionTime === null ? null : data?.averageResolutionTime + " " + (data?.averageResolutionTime === 1 ? t("COMMON_DAY") : t("COMMON_DAYS")) + " " + t("IS_AVG_COMPLAINT_RESOLUTION_TIME"),
                 staticData : data?.complaintTypes === 0 || data?.complaintTypes === null ? null : data?.complaintTypes
             }
             return pgrData;
-        }});
+        }}});
         return { isLoading, error, data, isSuccess };
     }
     const usePTDynamicData = () => {
@@ -56,51 +53,47 @@ const useDynamicData = ({moduleCode ,tenantId, filters, t }) => {
         }
 
         let filter2 = {...filter1, status: "ACTIVE"}
-        const { isLoading : isPTPropLoading, error: ptPropError, data: ptPropData, isSuccess : ptPropSuccess  } =  useQuery(['PT_OPEN_SEARCH_REG_PROP', tenantId, filter1], async () => await PTService.PTOpenSearch({ tenantId, filters: filter1 }), 
-        {select: (data) => {
+        const { isLoading : isPTPropLoading, error: ptPropError, data: ptPropData, isSuccess : ptPropSuccess  } =  queryTemplate({ queryKey: ['PT_OPEN_SEARCH_REG_PROP', tenantId, filter1], queryFn: async () => await PTService.PTOpenSearch({ tenantId, filters: filter1 }), config: {select: (data) => {
             const ptDataOne = {
                 dynamicDataOne : data?.count === 0 || data?.count === null ? null : data?.count + " " + t("PROPERTIES_REGISTERED_IN_LAST_12_MONTHS"),
             }
             return ptDataOne;
-        }});
+        }}});
 
-        const { isLoading : isPTAppLoading, error: ptAppError, data: ptAppData, isSuccess : ptAppSuccess  } =  useQuery(['PT_OPEN_SEARCH_APP_PROCESS', tenantId, filter2], async () => await PTService.PTOpenSearch({ tenantId, filters: filter2 }), 
-        {select: (data) => {
+        const { isLoading : isPTAppLoading, error: ptAppError, data: ptAppData, isSuccess : ptAppSuccess  } =  queryTemplate({ queryKey: ['PT_OPEN_SEARCH_APP_PROCESS', tenantId, filter2], queryFn: async () => await PTService.PTOpenSearch({ tenantId, filters: filter2 }), config: {select: (data) => {
             const ptDataTwo = {
                 dynamicDataTwo : data?.count === 0 || data?.count === null ? null : data?.count + " " + t("APPLICATION_PROCESSED_IN_LAST_12_MONTHS"),
             }
             return ptDataTwo;
-        }});
+        }}});
         return { isLoading : isPTPropLoading || isPTAppLoading, error : ptAppError || ptPropError, data : {...ptPropData, ...ptAppData}, isSuccess: ptPropSuccess && ptAppSuccess };
     }
 
     const useWSDynamicData = () => {
-        const { isLoading, error, data, isSuccess } =  useQuery(['WS_OPEN_SEARCH_DSS', tenantId], async () => await WSService.WSOpensearch({
+        const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['WS_OPEN_SEARCH_DSS', tenantId], queryFn: async () => await WSService.WSOpensearch({
             module: "WS",
             tenantId: tenantId
-        }), 
-        {select: (data) => {
+        }), config: {select: (data) => {
             const wsData = {
                 dynamicDataOne : data?.wstotalCollection === 0 || data?.wstotalCollection === null ? null : `₹ ${data?.wstotalCollection}` + " " +  t("PAID_IN_LAST_12_MONTHS_TOWARDS_WS_CHARGES"),
                 dynamicDataTwo : data?.wstotalConnection === 0 || data?.wstotalConnection === null ? null : data?.wstotalConnection + " " + t("ACTIVE_CONNECTIONS_PRESENT_IN") + " " + t(tenantId),
             }
             return wsData;
-        }});
+        }}});
         return { isLoading, error, data, isSuccess };
     }
 
     const useBPADynamicData = () => {
-        const { isLoading, error, data, isSuccess } =  useQuery(['BPA_OPEN_SEARCH_DSS', tenantId], async () => await OBPSService.BPAOpensearch({
+        const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['BPA_OPEN_SEARCH_DSS', tenantId], queryFn: async () => await OBPSService.BPAOpensearch({
             module: "BPA",
             tenantId: tenantId
-        }), 
-        {select: (data) => {
+        }), config: {select: (data) => {
             const obpsData = {
                 dynamicDataOne : data?.bpaTotalPermitsIssued === 0 || data?.bpaTotalPermitsIssued === null ? null : ` ${data?.bpaTotalPermitsIssued}` + " " +  t("PERMITS_ISSUED_IN_LAST_12_MONTHS"),
                 dynamicDataTwo : data?.bpaTotalPlansScrutinized === 0 || data?.bpaTotalPlansScrutinized === null ? null : data?.bpaTotalPlansScrutinized + " " + t("BUILING_PLANS_SCRUTINISED_IN_LAST_12_MONTHS"),
             }
             return obpsData;
-        }});
+        }}});
         return { isLoading, error, data, isSuccess };
     }
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useEmployeeSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useEmployeeSearch.js
@@ -1,10 +1,10 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useEmployeeSearch = (tenantId, filters, config = {}) => {
   if (filters.roles) {
     filters.roles = filters.roles.map((role) => role.code).join(",");
   }
-  return useQuery(["EMPLOYEE_SEARCH", filters], () => Digit.UserService.employeeSearch(tenantId, filters), config);
+  return queryTemplate({ queryKey: ["EMPLOYEE_SEARCH", filters], queryFn: () => Digit.UserService.employeeSearch(tenantId, filters), config });
 };
 
 export default useEmployeeSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useEnabledMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useEnabledMDMS.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 /**
  * Custom React Hook: useEnabledMDMS
@@ -23,7 +23,7 @@ import { useQuery } from "react-query";
  */
 
 const useEnabledMDMS = (tenantId, moduleName, masterDetails = [], config = {}) => {
-    return useQuery([tenantId, moduleName, masterDetails], () => Digit.Hooks.useSelectedMDMS(moduleName).getMultipleTypesWithFilter(tenantId, moduleName, masterDetails), config);
+    return queryTemplate({ queryKey: [tenantId, moduleName, masterDetails], queryFn: () => Digit.Hooks.useSelectedMDMS(moduleName).getMultipleTypesWithFilter(tenantId, moduleName, masterDetails), config });
 };
 
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useFeedBackSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useFeedBackSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
+import { useQueryClient } from "../common/queryClientTemplate";
 
 const useFeedBackSearch = ({ tenantId, filters }, config = {}) => {
     const client = useQueryClient();
@@ -6,12 +7,12 @@ const useFeedBackSearch = ({ tenantId, filters }, config = {}) => {
   let serviceSearchArg = {filters : {ServiceCriteria : {tenantId:filters?.serviceSearchArgs?.tenantId, referenceIds:filters?.serviceSearchArgs?.referenceIds}}}
   let serviceconfig = {/*enabled : data?.ServiceDefinition?.[0]?.id ? true : false,*/ cacheTime: 0}
   
-  const { isLoading : serviceLoading, error : serviceerror, data :servicedata} = useQuery(["ServiceSearch", tenantId, filters], () => Digit.PTService.cfsearch(serviceSearchArg), {
+  const { isLoading : serviceLoading, error : serviceerror, data :servicedata} = queryTemplate({ queryKey: ["ServiceSearch", tenantId, filters], queryFn: () => Digit.PTService.cfsearch(serviceSearchArg), config: {
       ...serviceconfig,
-      });
+      } });
   
   
-  return {isLoading: serviceLoading, error : serviceerror, data : servicedata, revalidate: () => client.invalidateQueries(["ServiceSearch", tenantId, filters]) };
+  return {isLoading: serviceLoading, error : serviceerror, data : servicedata, revalidate: () => client.invalidateQueries({ queryKey: ["ServiceSearch", tenantId, filters] }) };
 
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useGetFAQsJSON.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useGetFAQsJSON.js
@@ -1,7 +1,7 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useGetFAQsJSON = (tenantId) => {
-    return useQuery(["FAQ_S", tenantId], () => Digit.MDMSService.getFAQsJSONData(tenantId));
+    return queryTemplate({ queryKey: ["FAQ_S", tenantId], queryFn: () => Digit.MDMSService.getFAQsJSONData(tenantId) });
   };
 
 export default useGetFAQsJSON;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useHowItWorksJSON.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useHowItWorksJSON.js
@@ -1,7 +1,7 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useGetHowItWorksJSON = (tenantId) => {
-    return useQuery(["HOW_IT_WORKS", tenantId], () => Digit.MDMSService.getHowItWorksJSONData(tenantId));
+    return queryTemplate({ queryKey: ["HOW_IT_WORKS", tenantId], queryFn: () => Digit.MDMSService.getHowItWorksJSONData(tenantId) });
   };
 
 export default useGetHowItWorksJSON;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useInbox.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useInbox.js
@@ -1,11 +1,10 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { InboxGeneral } from "../services/elements/InboxService"
 
-const useInbox = ({tenantId, filters, config}) => useQuery(
-        ["INBOX_DATA",tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
-        () => InboxGeneral.Search({inbox: {...filters}}),
-        { ...config }
-    )
+const useInbox = ({tenantId, filters, config}) => queryTemplate({
+        queryKey: ["INBOX_DATA",tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
+        queryFn: () => InboxGeneral.Search({inbox: {...filters}}),
+        config,
+    })
 
 export default useInbox;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useInboxGeneral/useInboxGeneral.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useInboxGeneral/useInboxGeneral.js
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import { FSMService } from "../../services/elements/FSM";
 import { PTService } from "../../services/elements/PT";
 import { PTRService } from "../../services/elements/PTR";
@@ -74,7 +75,7 @@ const inboxConfig = (tenantId, filters) => ({
     businessIdAliasForSearch: "applicationNo",
     fetchFilters: filterFunctions.SV,
     _searchFn: () => SVService.search({ tenantId, filters }),
-  }
+  },
 });
 
 const defaultCombineResponse = ({ totalCount, ...d }, wf) => {
@@ -96,13 +97,6 @@ const defaultCatchSearch = (Err) => {
     return [];
   throw Err;
 };
-
-/**
- *
- * @param {*} data
- * @param {Array of Objects containing async or pure functions} middlewares
- * @returns {object}
- */
 
 const callMiddlewares = async (data, middlewares) => {
   let applyBreak = false;
@@ -142,20 +136,16 @@ const useInboxGeneral = ({
 
   let { workflowFilters, searchFilters } = fetchFilters(filters);
 
-  const { data: processInstances, isFetching: wfFetching, isFetched, isSuccess: wfSuccess } = useQuery(
-    ["WORKFLOW_INBOX", businessService, workflowFilters],
-    () =>
+  const { data: processInstances, isFetching: wfFetching, isFetched, isSuccess: wfSuccess } = queryTemplate({
+    queryKey: ["WORKFLOW_INBOX", businessService, workflowFilters],
+    queryFn: () =>
       Digit.WorkflowService.getAllApplication(tenantId, { businessServices: services.join(), ...workflowFilters })
         .then(rawWfHandler)
         .then((data) => callMiddlewares(data.ProcessInstances, middlewaresWf)),
-    {
-      enabled: isInbox,
-      select: (d) => {
-        return d;
-      },
-      ...wfConfig,
-    }
-  );
+    enabled: isInbox,
+    select: (d) => d,
+    config: wfConfig,
+  });
 
   const applicationNoFromWF = processInstances?.map((e) => e.businessId).join() || "";
 
@@ -164,36 +154,30 @@ const useInboxGeneral = ({
 
   const { _searchFn } = inboxConfig(tenantId, { ...searchFilters })[businessService];
 
-  /**
-   * Convert Wf Array to Object
-   */
-
   const processInstanceBuisnessIdMap = processInstances?.reduce((object, item) => {
     return { ...object, [item?.["businessId"]]: item };
   }, {});
 
   const allowSearch = isInbox ? isFetched && wfSuccess && !!searchFilters[businessIdsParamForSearch] : true;
 
-  const searchResult = useQuery(
-    ["SEARCH_INBOX", businessService, searchFilters, workflowFilters, isInbox],
-    () => {
+  const searchResult = queryTemplate({
+    queryKey: ["SEARCH_INBOX", businessService, searchFilters, workflowFilters, isInbox],
+    queryFn: () => {
       if (allowSearch)
         return _searchFn()
           .then((d) => rawSearchHandler(d, searchResponseKey, businessIdAliasForSearch))
           .then((data) => callMiddlewares(data[searchResponseKey], middlewareSearch))
           .catch(catchSearch);
     },
-    {
-      enabled: allowSearch,
-      select: (d) => {
-        return d.map((searchResult) => ({
-          totalCount: d.totalCount,
-          ...combineResponse(searchResult, processInstanceBuisnessIdMap?.[searchResult?.[businessIdAliasForSearch]]),
-        }));
-      },
-      ...searchConfig,
-    }
-  );
+    enabled: allowSearch,
+    select: (d) => {
+      return d.map((searchResult) => ({
+        totalCount: d.totalCount,
+        ...combineResponse(searchResult, processInstanceBuisnessIdMap?.[searchResult?.[businessIdAliasForSearch]]),
+      }));
+    },
+    config: searchConfig,
+  });
 
   const revalidate = () => {
     client.refetchQueries(["WORKFLOW_INBOX"]);
@@ -208,7 +192,6 @@ const useInboxGeneral = ({
     searchResponseKey,
     businessIdsParamForSearch,
     businessIdAliasForSearch,
-
     searchFields: getSearchFields(isInbox)[businessService],
     wfFetching,
   };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useInboxGeneral/useNewInbox.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useInboxGeneral/useNewInbox.js
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import { FSMService } from "../../services/elements/FSM";
 import { PTService } from "../../services/elements/PT";
 import { CHBServices } from "../../services/elements/CHB";
@@ -137,37 +138,28 @@ const useNewInboxGeneral = ({ tenantId, ModuleCode, filters, middleware = [], co
   const { fetchFilters, searchResponseKey, businessIdAliasForSearch, businessIdsParamForSearch } = inboxConfig()[ModuleCode];
   let { workflowFilters, searchFilters, limit, offset, sortBy, sortOrder,isDraftApplication } = fetchFilters(filters);
 
-  const query = useQuery(
-    ["INBOX", workflowFilters, searchFilters, ModuleCode, limit, offset, sortBy, sortOrder],
-    () =>
+  const query = queryTemplate({
+    queryKey: ["INBOX", workflowFilters, searchFilters, ModuleCode, limit, offset, sortBy, sortOrder],
+    queryFn: () =>
       InboxGeneral.Search({
-        inbox: { tenantId, processSearchCriteria: workflowFilters, moduleSearchCriteria: { ...searchFilters, sortBy, sortOrder,isDraftApplication }, limit, offset },
+        inbox: { tenantId, processSearchCriteria: workflowFilters, moduleSearchCriteria: { ...searchFilters, sortBy, sortOrder, isDraftApplication }, limit, offset },
       }),
-    {
-      select: (data) => {
-        const { statusMap, totalCount } = data;
-        // client.setQueryData(`INBOX_STATUS_MAP_${ModuleCode}`, (oldStatusMap) => {
-        //   if (!oldStatusMap) return statusMap;
-        //   else return [...oldStatusMap.filter((e) => statusMap.some((f) => f.stateId === e.stateId))];
-        // });
-
-        client.setQueryData(`INBOX_STATUS_MAP_${ModuleCode}`, statusMap);
-
-        if (data.items.length) {
-          return data.items?.map((obj) => ({
-            searchData: obj.businessObject,
-            workflowData: obj.ProcessInstance,
-            statusMap,
-            totalCount,
-          }));
-        } else {
-          return [{ statusMap, totalCount, dataEmpty: true }];
-        }
-      },
-      retry: false,
-      ...config,
-    }
-  );
+    select: (data) => {
+      const { statusMap, totalCount } = data;
+      client.setQueryData(`INBOX_STATUS_MAP_${ModuleCode}`, statusMap);
+      if (data.items.length) {
+        return data.items?.map((obj) => ({
+          searchData: obj.businessObject,
+          workflowData: obj.ProcessInstance,
+          statusMap,
+          totalCount,
+        }));
+      } else {
+        return [{ statusMap, totalCount, dataEmpty: true }];
+      }
+    },
+    config: { retry: false, ...config },
+  });
 
   return {
     ...query,

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useLocalities.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useLocalities.js
@@ -1,17 +1,18 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { getLocalities } from "../services/molecules/getLocalities";
 import { LocalityService } from "../services/elements/Localities";
 
 const useLocalities = (tenant, boundaryType = "admin", config, t) => {
   boundaryType = boundaryType.toLocaleLowerCase();
-  return useQuery(["BOUNDARY_DATA", tenant, boundaryType], () => getLocalities[boundaryType](tenant), {
+  return queryTemplate({
+    queryKey: ["BOUNDARY_DATA", tenant, boundaryType],
+    queryFn: () => getLocalities[boundaryType](tenant),
     select: (data) => {
       return LocalityService?.get(data).map((key) => {
         return { ...key, i18nkey: t(key.i18nkey) };
       });
     },
-    staleTime: Infinity,
-    ...config,
+    config: { staleTime: Infinity, ...config },
   });
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useMDMS.js
@@ -1,30 +1,29 @@
-import { MdmsService } from "../services/elements/MDMS";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useMDMS = (tenantId, moduleCode, type, config = {}, payload = []) => {
   const usePaymentGateway = () => {
-    return useQuery("PAYMENT_GATEWAY", () => MdmsService.getPaymentGateway(tenantId, moduleCode, type), {
+    return queryTemplate({ queryKey: ["PAYMENT_GATEWAY"], queryFn: () => MdmsService.getPaymentGateway(tenantId, moduleCode, type), config: {
       select: (data) => {
         return data?.[moduleCode]?.[type].filter((e) => e.active).map(({ gateway }) => gateway);
       },
       ...config,
-    });
+    } });
   };
 
   const useReceiptKey = () => {
-    return useQuery("RECEIPT_KEY", () => MdmsService.getReceiptKey(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["RECEIPT_KEY"], queryFn: () => MdmsService.getReceiptKey(tenantId, moduleCode, type), config });
   };
 
   const useBillsGenieKey = () => {
-    return useQuery("BILLS_GENIE_KEY", () => MdmsService.getBillsGenieKey(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["BILLS_GENIE_KEY"], queryFn: () => MdmsService.getBillsGenieKey(tenantId, moduleCode, type), config });
   };
 
   const useFSTPPlantInfo = () => {
-    return useQuery("FSTP_PLANTINFO", () => MdmsService.getFSTPPlantInfo(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["FSTP_PLANTINFO"], queryFn: () => MdmsService.getFSTPPlantInfo(tenantId, moduleCode, type), config });
   };
 
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useMDMSV2.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useMDMSV2.js
@@ -1,30 +1,29 @@
-import { MdmsServiceV2 } from "../services/elements/MDMSV2";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useMDMS = (tenantId, moduleCode, type, config = {}) => {
   const usePaymentGateway = () => {
-    return useQuery("PAYMENT_GATEWAY", () => MdmsServiceV2.getPaymentGateway(tenantId, moduleCode, type), {
+    return queryTemplate({ queryKey: ["PAYMENT_GATEWAY"], queryFn: () => MdmsServiceV2.getPaymentGateway(tenantId, moduleCode, type), config: {
       select: (data) => {
         return data?.[moduleCode]?.[type].filter((e) => e.active).map(({ gateway }) => gateway);
       },
       ...config,
-    });
+    } });
   };
 
   const useReceiptKey = () => {
-    return useQuery("RECEIPT_KEY", () => MdmsServiceV2.getReceiptKey(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["RECEIPT_KEY"], queryFn: () => MdmsServiceV2.getReceiptKey(tenantId, moduleCode, type), config });
   };
 
   const useBillsGenieKey = () => {
-    return useQuery("BILLS_GENIE_KEY", () => MdmsServiceV2.getBillsGenieKey(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["BILLS_GENIE_KEY"], queryFn: () => MdmsServiceV2.getBillsGenieKey(tenantId, moduleCode, type), config });
   };
 
   const useFSTPPlantInfo = () => {
-    return useQuery("FSTP_PLANTINFO", () => MdmsServiceV2.getFSTPPlantInfo(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: ["FSTP_PLANTINFO"], queryFn: () => MdmsServiceV2.getFSTPPlantInfo(tenantId, moduleCode, type), config });
   };
 
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsServiceV2.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsServiceV2.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useModuleTenants.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useModuleTenants.js
@@ -1,11 +1,12 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import { useTranslation } from "react-i18next";
 
 const useModuleTenants = (module, config = {}) => {
   const { t } = useTranslation();
 
-  return useQuery(["ULB_TENANTS", module], () => Digit.SessionStorage.get("initData"), {
+  return queryTemplate({
+    queryKey: ["ULB_TENANTS", module],
+    queryFn: () => Digit.SessionStorage.get("initData"),
     select: (data) => ({
       ddr: data.modules
         .find((e) => e.module === module)
@@ -33,7 +34,7 @@ const useModuleTenants = (module, config = {}) => {
           ),
         })),
     }),
-    ...config,
+    config: { ...config },
   });
 };
 export default useModuleTenants;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useStaticData.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useStaticData.js
@@ -1,7 +1,7 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useStaticData = (tenantId) => {
-    return useQuery(["MODULE_LEVEL_HOME_PAGE_STATIC_DATA", tenantId], () => Digit.MDMSService.getStaticDataJSON(tenantId));
+    return queryTemplate({ queryKey: ["MODULE_LEVEL_HOME_PAGE_STATIC_DATA", tenantId], queryFn: () => Digit.MDMSService.getStaticDataJSON(tenantId) });
   };
 
 export default useStaticData;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useStatusGeneral.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useStatusGeneral.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 const useApplicationStatusGeneral = ({ businessServices = [], tenantId }, config) => {
   tenantId = tenantId || Digit.ULBService.getCurrentTenantId();
@@ -34,7 +34,7 @@ const useApplicationStatusGeneral = ({ businessServices = [], tenantId }, config
     return { userRoleStates, otherRoleStates };
   };
 
-  const queryData = useQuery(["workflow_states", tenantId, ...businessServices], () => fetch(), { select, ...config });
+  const queryData = queryTemplate({ queryKey: ["workflow_states", tenantId, ...businessServices], queryFn: () => fetch(), select, config });
 
   return queryData;
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useStore.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useStore.js
@@ -1,10 +1,12 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 import StoreData from "../services/molecules/StoreData";
 
 const useStore = {
   getInitData: () =>
-    useQuery(["STORE_DATA"], () => StoreData.getInitData(), {
-      staleTime: Infinity,
+    queryTemplate({
+      queryKey: ["STORE_DATA"],
+      queryFn: () => StoreData.getInitData(),
+      config: { staleTime: Infinity },
     }),
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useTenants.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/useTenants.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
 
 // Sort function
 const alphabeticalSortFunctionForTenantsBasedOnName = (firstEl, secondEl) => {
@@ -40,4 +40,4 @@ const alphabeticalSortFunctionForTenantsBasedOnName = (firstEl, secondEl) => {
 };
 
 
-export const useTenants = () => useQuery(["ALL_TENANTS"], () => Digit.SessionStorage.get("initData").tenants.sort(alphabeticalSortFunctionForTenantsBasedOnName))
+export const useTenants = () => queryTemplate({ queryKey: ["ALL_TENANTS"], queryFn: () => Digit.SessionStorage.get("initData").tenants.sort(alphabeticalSortFunctionForTenantsBasedOnName) })

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/userSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/userSearch.js
@@ -1,8 +1,9 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
+import { useQueryClient } from "../common/queryClientTemplate";
 import { UserService } from "../services/elements/User";
 
 export const useUserSearch = (tenantId, data, filters, options = {}) => {
   const client = useQueryClient();
-  const queryData = useQuery(["USER_SEARCH", filters, data], () => UserService.userSearch(tenantId, data, filters), options);
-  return { ...queryData, revalidate: () => client.invalidateQueries(["USER_SEARCH", filters, data]) };
+  const queryData = queryTemplate({ queryKey: ["USER_SEARCH", filters, data], queryFn: () => UserService.userSearch(tenantId, data, filters), config: options });
+  return { ...queryData, revalidate: () => client.invalidateQueries({ queryKey: ["USER_SEARCH", filters, data] }) };
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useEmpvendorCommonSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useEmpvendorCommonSearch.js
@@ -1,22 +1,18 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
-const useEmpvendorCommonSearch = ({tenantId,filters, auth, searchedFrom=""},config = {}) => {
+const useEmpvendorCommonSearch = ({ tenantId, filters, auth, searchedFrom = "" }, config = {}) => {
   const client = useQueryClient();
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
 
   const defaultSelect = (data) => {
-    if(data.VendorDetails.length > 0) data.VendorDetails[0] = data.VendorDetails[0] || [];
+    if (data.VendorDetails.length > 0) data.VendorDetails[0] = data.VendorDetails[0] || [];
     return data;
   };
 
   console.log("useempvendorCommonSearch hook", tenantId, filters, auth, config);
-  const { isLoading, error, data, isSuccess } = useQuery([tenantId, filters, auth, config], () => Digit.VendorService.vendorcommonSearch(args), {
-    select: defaultSelect,
-    ...config,
-  });
-  return {isLoading,error, data, isSuccess, revalidate: () => client.invalidateQueries([tenantId, filters, auth])};
-
-
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: [tenantId, filters, auth, config], queryFn: () => Digit.VendorService.vendorcommonSearch(args), select: defaultSelect, config });
+  return { isLoading, error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: [tenantId, filters, auth] }) };
 };
 
 export default useEmpvendorCommonSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useEmpvendorCreate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useEmpvendorCreate.js
@@ -1,11 +1,9 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { VendorService } from "../../services/elements/EmpVendor";
-
-
 
 const useEmpvendorCreate = (args) => {
   const { tenantId, filters, config } = args;
-  return useQuery(["EMP_VENDOR_CREATE", filters], () => VendorService.createVendor(tenantId, filters), config);
+  return queryTemplate({ queryKey: ["EMP_VENDOR_CREATE", filters], queryFn: () => VendorService.createVendor(tenantId, filters), config });
 };
 
 export default useEmpvendorCreate;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useEmpvendorSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useEmpvendorSearch.js
@@ -1,11 +1,9 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { VendorService } from "../../services/elements/EmpVendor";
-
-
 
 const useEmpvendorSearch = (args) => {
   const { tenantId, filters, config } = args;
-  return useQuery(["EMP_VENDOR_SEARCH", filters], () => VendorService.vendorSearch(tenantId, filters), config);
+  return queryTemplate({ queryKey: ["EMP_VENDOR_SEARCH", filters], queryFn: () => VendorService.vendorSearch(tenantId, filters), config });
 };
 
 export default useEmpvendorSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useVendorAdditionaldetailsAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/vendor/useVendorAdditionaldetailsAPI.js
@@ -1,15 +1,9 @@
-import { useQuery, useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import { VendorService } from "../../services/elements/EmpVendor";
-
-
 
 const useVendorAdditionaldetailsAPI = (tenantId) => {
   console.log("data in api hook cakll :: ", tenantId);
-  // return useQuery(["EMP_VENDOR_ADDITIONAL_DETAILS_CREATE", filters], () => VendorService.createVendorAdditionaldetails(tenantId, filters), config);
-
-  return useMutation((data) => VendorService.createVendorAdditionaldetails(data, tenantId));
-
-
+  return mutationTemplate({ mutationFn: (data) => VendorService.createVendorAdditionaldetails(data, tenantId) });
 };
 
 export default useVendorAdditionaldetailsAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/workflow.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/workflow.js
@@ -1,19 +1,20 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../common/queryTemplate";
+import { useQueryClient } from "../common/queryClientTemplate";
 
 const useWorkflowDetails = ({ tenantId, id, moduleCode, role = "CITIZEN", serviceData = {}, getStaleData,  getTripData = false,config }) => {
   const queryClient = useQueryClient();
 
   const staleDataConfig = { staleTime: Infinity };
 
-  const { isLoading, error, isError, data } = useQuery(
-    ["workFlowDetails", tenantId, id, moduleCode, role, config],
-    () => Digit.WorkflowService.getDetailsById({ tenantId, id, moduleCode, role, getTripData }),
-    getStaleData ? { ...staleDataConfig, ...config } : config
-  );
+  const { isLoading, error, isError, data } = queryTemplate({
+    queryKey: ["workFlowDetails", tenantId, id, moduleCode, role, config],
+    queryFn: () => Digit.WorkflowService.getDetailsById({ tenantId, id, moduleCode, role, getTripData }),
+    config: getStaleData ? { ...staleDataConfig, ...config } : config,
+  });
 
   if (getStaleData) return { isLoading, error, isError, data };
 
-  return { isLoading, error, isError, data, revalidate: () => queryClient.invalidateQueries(["workFlowDetails", tenantId, id, moduleCode, role]) };
+  return { isLoading, error, isError, data, revalidate: () => queryClient.invalidateQueries({ queryKey: ["workFlowDetails", tenantId, id, moduleCode, role] }) };
 };
 
 export default useWorkflowDetails;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/WSSearchMdmsTypes.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/WSSearchMdmsTypes.js
@@ -1,22 +1,19 @@
-import { useQuery } from "react-query";
-import { getMultipleTypes, MdmsService, getGeneralCriteria } from "../../services/elements/MDMS"
+import { queryTemplate } from "../../common/queryTemplate";
+import { getMultipleTypes, MdmsService } from "../../services/elements/MDMS"
 
 const WSSearchMdmsTypes = {
   useWSMDMSBillAmendment: ({tenantId, config={}}) => {
     const BillAmendmentMdmsDetails = getMultipleTypes(tenantId, "BillAmendment", ["documentObj", "DemandRevisionBasis"])
-    return useQuery([tenantId, "WS_BILLAMENDMENT_MDMS"], () => MdmsService.getDataByCriteria(tenantId, BillAmendmentMdmsDetails, "BillAmendment"), {
-      select: ({BillAmendment}) => {
+    return queryTemplate({ queryKey: [tenantId, "WS_BILLAMENDMENT_MDMS"], queryFn: () => MdmsService.getDataByCriteria(tenantId, BillAmendmentMdmsDetails, "BillAmendment"), select: ({BillAmendment}) => {
         return BillAmendment?.DemandRevisionBasis.map( (e, index) => {
           return { ...e, i18nKey: `DEMAND_REVISION_BASIS_${e.code}`, allowedDocuments: BillAmendment?.documentObj[index] }
         })
-      },
-      ...config
-    });
+      }, config });
   },
   useWSServicesMasters: (tenantId, type) =>
-    useQuery(
-      [tenantId, type, "WS_WS_SERVICES_MASTERS"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, type, "WS_WS_SERVICES_MASTERS"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -36,8 +33,7 @@ const WSSearchMdmsTypes = {
           },
           "ws-services-masters"
         ),
-      {
-        select: (data) => {
+      select: (data) => {
           const wsDocsData = type ? type : "Documents";
           data?.["ws-services-masters"]?.[wsDocsData]?.forEach(type => {
             type.code = type.code;
@@ -47,14 +43,13 @@ const WSSearchMdmsTypes = {
             })
           })
           return data?.["ws-services-masters"] ? data?.["ws-services-masters"] : []
-        }
-      }
-    ),
+        },
+    }),
 
   useWSServicesCalculation: (tenantId) =>
-    useQuery(
-      [tenantId, "WS_WS_SERVICES_CALCULATION"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, "WS_WS_SERVICES_CALCULATION"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -74,15 +69,13 @@ const WSSearchMdmsTypes = {
           },
           "ws-services-calculation"
         ),
-      {
-        select: (data) => {
+      select: (data) => {
           data?.["ws-services-calculation"]?.PipeSize?.forEach(type => {
             type.i18nKey = type.size ? `${type.size} Inches` : "";
           })
           return data?.["ws-services-calculation"] ? data?.["ws-services-calculation"] : []
-        }
-      }
-    ),
+        },
+    }),
 };
 
 export default WSSearchMdmsTypes;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useApplicationActions.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useApplicationActions.js
@@ -1,8 +1,8 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActions from "../../services/molecules/WS/ApplicationUpdateActions";
 
 const useApplicationActions = (businessService) => {
-  return useMutation((applicationData) => ApplicationUpdateActions(applicationData, businessService));
+  return mutationTemplate({ mutationFn: (applicationData) => ApplicationUpdateActions(applicationData, businessService) });
 };
 
 export default useApplicationActions;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useApplicationActionsBillAmendUpdate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useApplicationActionsBillAmendUpdate.js
@@ -1,8 +1,8 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActionsBillAmendUpdate from "../../services/molecules/WS/ApplicationUpdateActionsBillAmendUpdate";
 
 const useApplicationActionsBillAmendUpdate = () => {
-    return useMutation((applicationData) => ApplicationUpdateActionsBillAmendUpdate(applicationData));
+    return mutationTemplate({ mutationFn: (applicationData) => ApplicationUpdateActionsBillAmendUpdate(applicationData) });
 };
 
 export default useApplicationActionsBillAmendUpdate;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useBillingPeriodValidation.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useBillingPeriodValidation.js
@@ -1,7 +1,7 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useGetBillingPeriodValidation = (tenantId) => {
-    return useQuery(["getBillingPeriod", tenantId], () => Digit.MDMSService.getBillingPeriod(tenantId));
+    return queryTemplate({ queryKey: ["getBillingPeriod", tenantId], queryFn: () => Digit.MDMSService.getBillingPeriod(tenantId) });
   };
 
 export default useGetBillingPeriodValidation;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useBulkMeterCreate.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useBulkMeterCreate.js
@@ -1,8 +1,8 @@
 import { WSService } from "../../services/elements/WS";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useBulkMeterReadingCreateAPI = (businessService = "WS") => {
-    return useMutation((data) => WSService.bulkMeterConnectioncreate(data, businessService));
+    return mutationTemplate({ mutationFn: (data) => WSService.bulkMeterConnectioncreate(data, businessService) });
 };
 
 export default useBulkMeterReadingCreateAPI; 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useBulkSearchWS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useBulkSearchWS.js
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS";
 /*
  * Feature :: Privacy
@@ -8,13 +7,11 @@ import { WSService } from "../../services/elements/WS";
 
 const useBulkSearchWS = ({ tenantId,  filters, config = {}}) => {
   let responseWS = "";
-  responseWS=useQuery(
-      ["WS_WATER_SEARCH",tenantId, ...Object.keys(filters)?.map((e) => filters?.[e])],
-      async () => await WSService.WSMeterSearch({tenantId, filters }),
-      {
-        ...config,
-      }
-    )
+  responseWS=queryTemplate({
+      queryKey: ["WS_WATER_SEARCH",tenantId, ...Object.keys(filters)?.map((e) => filters?.[e])],
+      queryFn: async () => await WSService.WSMeterSearch({tenantId, filters }),
+      config,
+    })
     return responseWS?.data
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useConnectionDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useConnectionDetail.js
@@ -1,19 +1,20 @@
 import { WSSearch } from "../../services/molecules/WS/Search";
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useConnectionDetail = (t, tenantId, connectionNumber, serviceType, config = {}) => {
   const client = useQueryClient();
-  const { isLoading, error, data, isSuccess } = useQuery(
-    ["APPLICATION_WS_SEARCH", "WNS_SEARCH", connectionNumber, serviceType, config],
-    () => WSSearch.connectionDetails(t, tenantId, connectionNumber, serviceType),
-    config
-  );
+  const { isLoading, error, data, isSuccess } = queryTemplate({
+    queryKey: ["APPLICATION_WS_SEARCH", "WNS_SEARCH", connectionNumber, serviceType, config],
+    queryFn: () => WSSearch.connectionDetails(t, tenantId, connectionNumber, serviceType),
+    config,
+  });
   return {
     isLoading,
     error,
     data,
     isSuccess,
-    revalidate: () => client.invalidateQueries(["APPLICATION_WS_SEARCH", "WNS_SEARCH", connectionNumber, serviceType]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["APPLICATION_WS_SEARCH", "WNS_SEARCH", connectionNumber, serviceType] }),
   };
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useConsumptionSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useConsumptionSearch.js
@@ -1,10 +1,9 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS";
 
   
 const useConsumptionSearch = ({tenantId, filters = {}, BusinessService="WS", t}, config = {}) => {
-  const { isLoading, error, data, isSuccess } =  useQuery(['WS_SEARCH', tenantId, filters, BusinessService], async () => await WSService.consumptionSearch({tenantId, filters: { ...filters }, businessService:BusinessService})
-  , config)
+  const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['WS_SEARCH', tenantId, filters, BusinessService], queryFn: async () => await WSService.consumptionSearch({tenantId, filters: { ...filters }, businessService:BusinessService}), config })
   return { isLoading, error, data, isSuccess };
 }
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useCreateBillAmendment.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useCreateBillAmendment.js
@@ -1,8 +1,8 @@
-import { useMutation } from "react-query"
+import { mutationTemplate } from "../../common/mutationTemplate"
 import Create from "../../services/molecules/WS/Create"
 
 const useCreateBillAmendment = () => {
-    return useMutation((data) => Create.BillAmendment(data))
+    return mutationTemplate({ mutationFn: (data) => Create.BillAmendment(data) })
 }
 
 export default useCreateBillAmendment

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useDisConnectionDetails.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useDisConnectionDetails.js
@@ -1,12 +1,12 @@
 import { WSSearch } from "../../services/molecules/WS/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useDisConnectionDetails = (t, tenantId, applicationNumber, serviceType, config = {}) => {
-  return useQuery(
-    ["APPLICATION_WS_SEARCH", "WNS_SEARCH", applicationNumber, serviceType,config],
-    () => WSSearch.disConnectionDetails(t, tenantId, applicationNumber, serviceType),
-    {...config}
-  );
+  return queryTemplate({
+    queryKey: ["APPLICATION_WS_SEARCH", "WNS_SEARCH", applicationNumber, serviceType,config],
+    queryFn: () => WSSearch.disConnectionDetails(t, tenantId, applicationNumber, serviceType),
+    config,
+  });
 };
 
 export default useDisConnectionDetails;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useDisconnectionWorkflow.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useDisconnectionWorkflow.js
@@ -1,15 +1,15 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useDisconnectionWorkflow = ({ tenantId }) => {
 
-  const { isLoading, error, isError, data } = useQuery(
-    ["disconnectWorkFlowDetails", tenantId],
-    () => Digit.WorkflowService.init(tenantId, "DisconnectWSConnection"),
-    {select: (data) => {
+  const { isLoading, error, isError, data } = queryTemplate({
+    queryKey: ["disconnectWorkFlowDetails", tenantId],
+    queryFn: () => Digit.WorkflowService.init(tenantId, "DisconnectWSConnection"),
+    select: (data) => {
         return{
             slaDays: data?.BusinessServices[0]?.businessServiceSla / (1000 * 60 * 60 * 24)
         } 
-    }} );
+    } });
 
 
   return { isLoading, error, isError, data };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useGetMeterStatusList.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useGetMeterStatusList.js
@@ -1,7 +1,7 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useGetMeterStatusList = (tenantId) => {
-    return useQuery(["getMeterStatus", tenantId], () => Digit.MDMSService.getMeterStatusType(tenantId));
+    return queryTemplate({ queryKey: ["getMeterStatus", tenantId], queryFn: () => Digit.MDMSService.getMeterStatusType(tenantId) });
   };
 
 export default useGetMeterStatusList;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMeterConnectionCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMeterConnectionCreateAPI.js
@@ -1,8 +1,8 @@
 import { WSService } from "../../services/elements/WS";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useMeterReadingCreateAPI = (businessService = "WS") => {
-    return useMutation((data) => WSService.meterConnectioncreate(data, businessService));
+    return mutationTemplate({ mutationFn: (data) => WSService.meterConnectioncreate(data, businessService) });
 };
 
 export default useMeterReadingCreateAPI; 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMyApplicationSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMyApplicationSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import { WSService } from "../../services/elements/WS";
 import { PTService } from "../../services/elements/PT";
 import cloneDeep from "lodash/cloneDeep";
@@ -6,16 +7,12 @@ import cloneDeep from "lodash/cloneDeep";
 const useMyApplicationSearch = ({tenantId, filters = {}, BusinessService="WS", t}, config = {}, getWorkflow = false) => {
   const client = useQueryClient();
 
-  const { isLoading, error, data, isSuccess } =  useQuery(['WS_SEARCH', tenantId, filters, BusinessService, config], async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService})
-  , {
-    ...config,
-    refetchOnMount: "always"
-  });
+  const { isLoading, error, data, isSuccess } =  queryTemplate({ queryKey: ['WS_SEARCH', tenantId, filters, BusinessService, config], queryFn: async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService}), config: { ...config, refetchOnMount: "always" } });
 
   const user = Digit.UserService.getUser();
   const tenant = Digit.SessionStorage.get("CITIZEN.COMMON.HOME.CITY")?.code || user?.info?.permanentCity || Digit.ULBService.getCurrentTenantId();
 
-  const { isLoading : isWSLoading , error : isWSError, data : wsData, isSuccess: wsSuccess } =  useQuery(['WS_SEARCH_CONNECTION', tenant, BusinessService, data, config], async () => await WSService.search({tenantId : tenant, filters: 
+  const { isLoading : isWSLoading , error : isWSError, data : wsData, isSuccess: wsSuccess } =  queryTemplate({ queryKey: ['WS_SEARCH_CONNECTION', tenant, BusinessService, data, config], queryFn: async () => await WSService.search({tenantId : tenant, filters: 
     isSuccess && data?.WaterConnection ? 
     { 
       connectionNumber : data?.WaterConnection?.[0]?.connectionNo  
@@ -24,11 +21,7 @@ const useMyApplicationSearch = ({tenantId, filters = {}, BusinessService="WS", t
     {
       connectionNumber : data?.SewerageConnections?.[0]?.connectionNo
     }
-    , businessService:BusinessService})
-  , {
-    enabled: isSuccess && getWorkflow,
-    refetchOnMount: "always"
-  })
+    , businessService:BusinessService}), config: { enabled: isSuccess && getWorkflow, refetchOnMount: "always" } })
 
   let businessIds = [];
 
@@ -39,10 +32,7 @@ const useMyApplicationSearch = ({tenantId, filters = {}, BusinessService="WS", t
     });
   }
   else{}
-  const { isLoading: isWorkflowLoading, data: workflowData } =  useQuery(['WS_SEARCH_WROKFLOW', tenant, wsData], async () => await Digit.WorkflowService.getByBusinessId(tenant, businessIds.join(",")), 
-  {
-    enabled: isSuccess && getWorkflow && wsSuccess,
-    select: (data) => {
+  const { isLoading: isWorkflowLoading, data: workflowData } =  queryTemplate({ queryKey: ['WS_SEARCH_WROKFLOW', tenant, wsData], queryFn: async () => await Digit.WorkflowService.getByBusinessId(tenant, businessIds.join(",")), select: (data) => {
       let isApplicationApproved = false
       if(data?.ProcessInstances.length > 0){
         isApplicationApproved = data?.ProcessInstances?.[0]?.state?.isTerminateState
@@ -53,14 +43,13 @@ const useMyApplicationSearch = ({tenantId, filters = {}, BusinessService="WS", t
       return {
         checkWorkFlow : isApplicationApproved
       };
-    }
-  } );
+    }, config: { enabled: isSuccess && getWorkflow && wsSuccess } } );
   return { 
     isLoading : !getWorkflow ? isLoading : isLoading || isWSLoading || isWorkflowLoading , 
     error, 
     data : !getWorkflow ? data : {...data, ...workflowData}, 
     isSuccess,
-    revalidate: () => client.invalidateQueries(["WS_SEARCH", tenantId, filters, BusinessService, config])
+    revalidate: () => client.invalidateQueries({ queryKey: ["WS_SEARCH", tenantId, filters, BusinessService, config] })
   };
     
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMyBillsSewarageSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMyBillsSewarageSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import _ from "lodash";
 import { WSService } from "../../services/elements/WS";
 import { PTService } from "../../services/elements/PT";
@@ -55,8 +56,7 @@ const combineResponse = (SewerageConnections, properties, billData, t) => {
 
 const useMyBillsSewarageSearch = ({tenantId, filters = {}, BusinessService="WS", t }, config = {}) => {
   const client = useQueryClient();
-  const { isLoading, error, data, isSuccess } = useQuery(['WS_SEARCH', tenantId, filters, BusinessService, config], async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService})
-  , config)
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ['WS_SEARCH', tenantId, filters, BusinessService, config], queryFn: async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService}), config })
     let propertyids = "";
     let consumercodes = "";
     data?.SewerageConnections?.forEach( item => {
@@ -66,20 +66,18 @@ const useMyBillsSewarageSearch = ({tenantId, filters = {}, BusinessService="WS",
     let propertyfilter = { propertyIds : propertyids.substring(0, propertyids.length-1),}
     if(propertyids !== "" && filters?.locality) propertyfilter.locality = filters?.locality;
     config={...config, enabled:propertyids!==""?true:false}
-  const { isLoading : isPropertyLoading, error : isPropertyError, data: propertyData , isSuccess : isPropertySuccess } = useQuery(['WSP_SEARCH', tenantId, propertyfilter,BusinessService,config], async () => await PTService.search({ tenantId: null , filters:propertyfilter, auth:filters?.locality?false:true })
-  , config)
-  const { isLoading : isBillLoading, error : isBillError, data: bill , isSuccess : isBillSuccess } = useQuery(['BILL_SEARCH', tenantId, consumercodes,BusinessService, config ], async () => await Digit.PaymentService.fetchBill(tenantId, {
+  const { isLoading : isPropertyLoading, error : isPropertyError, data: propertyData , isSuccess : isPropertySuccess } = queryTemplate({ queryKey: ['WSP_SEARCH', tenantId, propertyfilter,BusinessService,config], queryFn: async () => await PTService.search({ tenantId: null , filters:propertyfilter, auth:filters?.locality?false:true }), config })
+  const { isLoading : isBillLoading, error : isBillError, data: bill , isSuccess : isBillSuccess } = queryTemplate({ queryKey: ['BILL_SEARCH', tenantId, consumercodes,BusinessService, config ], queryFn: async () => await Digit.PaymentService.fetchBill(tenantId, {
     businessService: BusinessService,
     consumerCode: consumercodes.substring(0, consumercodes.length-1),
-  })
-  , config)
+  }), config })
 
   const response = {
     isLoading, 
     error,
     data,
     isSuccess,
-    revalidate: () => client.invalidateQueries(["WS_SEARCH", tenantId, filters, BusinessService]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["WS_SEARCH", tenantId, filters, BusinessService] }),
   } ;
 
   const properties =  {
@@ -87,7 +85,7 @@ const useMyBillsSewarageSearch = ({tenantId, filters = {}, BusinessService="WS",
     isPropertyError,
     propertyData,
     isPropertySuccess,
-    revalidate: () => client.invalidateQueries(["WSP_SEARCH", tenantId, propertyfilter,BusinessService]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["WSP_SEARCH", tenantId, propertyfilter,BusinessService] }),
   } ;
 
   const billData = {
@@ -95,7 +93,7 @@ const useMyBillsSewarageSearch = ({tenantId, filters = {}, BusinessService="WS",
     isBillError,
     bill,
     isBillSuccess,
-    revalidate: () => client.invalidateQueries(["BILL_SEARCH", tenantId, consumercodes,BusinessService]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["BILL_SEARCH", tenantId, consumercodes,BusinessService] }),
   } ;
 
   return (response?.isLoading || properties?.isPropertyLoading || billData?.isBillLoading) ? undefined : (billData?.bill?.Bill?.length === 0 || billData?.bill?.Bill === undefined ? [] : combineResponse(response?.data?.SewerageConnections,properties?.propertyData?.Properties,billData?.bill?.Bill, t));

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMyBillsWaterSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMyBillsWaterSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import { WSService } from "../../services/elements/WS";
 import { PTService } from "../../services/elements/PT";
 import _ from "lodash";
@@ -54,8 +55,7 @@ const combineResponse = (WaterConnections, properties, billData, t) => {
 
 const useMyBillsWaterSearch = ({tenantId, filters = {}, BusinessService="WS", t }, config = {}) => {
   const client = useQueryClient();
-  const { isLoading, error, data, isSuccess } = useQuery(['WS_SEARCH', tenantId, filters, BusinessService, config], async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService})
-  , config)
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ['WS_SEARCH', tenantId, filters, BusinessService, config], queryFn: async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService}), config })
     let propertyids = "";
     let consumercodes = "";
     if(BusinessService === "WS")
@@ -71,20 +71,18 @@ const useMyBillsWaterSearch = ({tenantId, filters = {}, BusinessService="WS", t 
     let propertyfilter = { propertyIds : propertyids.substring(0, propertyids.length-1),}
     if(propertyids !== "" && filters?.locality) propertyfilter.locality = filters?.locality;
     config={...config, enabled:propertyids!==""?true:false}
-  const { isLoading : isPropertyLoading, error : isPropertyError, data: propertyData , isSuccess : isPropertySuccess } = useQuery(['WSP_SEARCH', tenantId, propertyfilter,BusinessService, config], async () => await PTService.search({ tenantId: null , filters:propertyfilter, auth:filters?.locality?false:true })
-  , config)
-  const { isLoading : isBillLoading, error : isBillError, data: bill , isSuccess : isBillSuccess } = useQuery(['BILL_SEARCH', tenantId, consumercodes,BusinessService, config ], async () => await Digit.PaymentService.fetchBill(tenantId, {
+  const { isLoading : isPropertyLoading, error : isPropertyError, data: propertyData , isSuccess : isPropertySuccess } = queryTemplate({ queryKey: ['WSP_SEARCH', tenantId, propertyfilter,BusinessService, config], queryFn: async () => await PTService.search({ tenantId: null , filters:propertyfilter, auth:filters?.locality?false:true }), config })
+  const { isLoading : isBillLoading, error : isBillError, data: bill , isSuccess : isBillSuccess } = queryTemplate({ queryKey: ['BILL_SEARCH', tenantId, consumercodes,BusinessService, config ], queryFn: async () => await Digit.PaymentService.fetchBill(tenantId, {
     businessService: BusinessService,
     consumerCode: consumercodes.substring(0, consumercodes.length-1),
-  })
-  , config)
+  }), config })
 
   const response = {
     isLoading, 
     error,
     data,
     isSuccess,
-    revalidate: () => client.invalidateQueries(["WS_SEARCH", tenantId, filters, BusinessService]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["WS_SEARCH", tenantId, filters, BusinessService] }),
   } ;
 
   const properties =  {
@@ -92,7 +90,7 @@ const useMyBillsWaterSearch = ({tenantId, filters = {}, BusinessService="WS", t 
     isPropertyError,
     propertyData,
     isPropertySuccess,
-    revalidate: () => client.invalidateQueries(["WSP_SEARCH", tenantId, propertyfilter,BusinessService]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["WSP_SEARCH", tenantId, propertyfilter,BusinessService] }),
   } ;
 
   const billData = {
@@ -100,7 +98,7 @@ const useMyBillsWaterSearch = ({tenantId, filters = {}, BusinessService="WS", t 
     isBillError,
     bill,
     isBillSuccess,
-    revalidate: () => client.invalidateQueries(["BILL_SEARCH", tenantId, consumercodes,BusinessService]),
+    revalidate: () => client.invalidateQueries({ queryKey: ["BILL_SEARCH", tenantId, consumercodes,BusinessService] }),
   } ;
 
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMypaymentWS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useMypaymentWS.js
@@ -1,14 +1,13 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 export const useMypaymentWS = ({ tenantId, filters, BusinessService="WS",searchedFrom="" }, config = {}) => {
   const client = useQueryClient();
   const args = tenantId ? { tenantId, filters, BusinessService } : { filters, BusinessService };
 
-  const { isLoading, error, data, isSuccess } = useQuery(["WSSearchList", tenantId, filters, BusinessService], () => Digit.WSService.paymentsearch(args), {
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ["WSSearchList", tenantId, filters, BusinessService], queryFn: () => Digit.WSService.paymentsearch(args), config });
 
-  return {isLoading,error, data, isSuccess, revalidate: () => client.invalidateQueries(["WSSearchList", tenantId, filters, auth]) };
+  return {isLoading,error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: ["WSSearchList", tenantId, filters, BusinessService] }) };
 
 };
 export default useMypaymentWS

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useOldValue.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useOldValue.js
@@ -1,14 +1,12 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS";
 
 const useOldValue = ({ tenantId, filters, businessService }, config = {}) => {
-  return useQuery(
-    ["WS_WATER_SEARCH", tenantId, filters, businessService],
-    async () => await WSService.search({ tenantId, filters, businessService: businessService === "WATER" ? "WS" : "SW" }),
-    {
-      ...config,
-    }
-  );
+  return queryTemplate({
+    queryKey: ["WS_WATER_SEARCH", tenantId, filters, businessService],
+    queryFn: async () => await WSService.search({ tenantId, filters, businessService: businessService === "WATER" ? "WS" : "SW" }),
+    config,
+  });
 };
 
 export default useOldValue;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSearch.js
@@ -1,15 +1,12 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS"
 
 //while registering it's name is WSuseSearch
-const useSearch = ({tenantId, filters, config={}}) => useQuery(
-    ["WS_WATER_SEARCH", tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
-    () => WSService.WSWatersearch({tenantId, filters}),
-    {
-        ...config
-    }
- )
+const useSearch = ({tenantId, filters, config={}}) => queryTemplate({
+    queryKey: ["WS_WATER_SEARCH", tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
+    queryFn: () => WSService.WSWatersearch({tenantId, filters}),
+    config,
+ })
 
 
 export default useSearch

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSearchWS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSearchWS.js
@@ -1,5 +1,4 @@
-import React, { useState } from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS";
 import { PTService } from "../../services/elements/PT";
 /*
@@ -53,35 +52,35 @@ const useSearchWS = ({ tenantId, filters, config = {}, bussinessService, t, shor
   let consumercodes = [];
   let billData = "";
   if (bussinessService === "WS") {
-    responseWS = useQuery(
-      ["WS_WATER_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
-      async () => await WSService.WSWatersearch({ tenantId, filters }),
+    responseWS = queryTemplate(
       {
-        ...config,
+        queryKey: ["WS_WATER_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
+        queryFn: async () => await WSService.WSWatersearch({ tenantId, filters }),
+        config,
       }
     );
   } else if (bussinessService === "SW") {
-    responseSW = useQuery(
-      ["WS_SEW_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
-      async () => await WSService.WSSewsearch({ tenantId, filters }),
+    responseSW = queryTemplate(
       {
-        ...config,
+        queryKey: ["WS_SEW_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
+        queryFn: async () => await WSService.WSSewsearch({ tenantId, filters }),
+        config,
       }
     );
   } else {
-    responseWS = useQuery(
-      ["WS_WATER_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
-      async () => await WSService.WSWatersearch({ tenantId, filters }),
+    responseWS = queryTemplate(
       {
-        ...config,
+        queryKey: ["WS_WATER_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
+        queryFn: async () => await WSService.WSWatersearch({ tenantId, filters }),
+        config,
       }
     );
 
-    responseSW = useQuery(
-      ["WS_SEW_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
-      async () => await WSService.WSSewsearch({ tenantId, filters }),
+    responseSW = queryTemplate(
       {
-        ...config,
+        queryKey: ["WS_SEW_SEARCH", tenantId, ...Object.keys(filters)?.map((e) => filters?.[e]), bussinessService],
+        queryFn: async () => await WSService.WSSewsearch({ tenantId, filters }),
+        config,
       }
     );
   }
@@ -97,22 +96,26 @@ const useSearchWS = ({ tenantId, filters, config = {}, bussinessService, t, shor
   });
 
   let propertyfilter = { propertyIds: propertyids.substring(0, propertyids.length - 1) };
-  billData = useQuery(
-    ["BILL_SEARCH", tenantId, consumercodes.join(","), bussinessService],
-    async () =>
+  billData = queryTemplate(
+    {
+      queryKey: ["BILL_SEARCH", tenantId, consumercodes.join(","), bussinessService],
+      queryFn: async () =>
       await Digit.PaymentService.fetchBill(tenantId, {
         businessService: bussinessService,
         consumerCode: consumercodes.join(","),
       }),
-    { ...config, enabled: consumercodes.length > 0 }
+      config: { ...config, enabled: consumercodes.length > 0 },
+    }
   );
 
-  const properties = useQuery(
-    ["WSP_SEARCH", tenantId, propertyfilter, bussinessService],
-    async () => await PTService.search({ tenantId: tenantId, filters: propertyfilter, auth: true }),
+  const properties = queryTemplate(
     {
-      ...config,
-      enabled: !!(propertyids !== ""),
+      queryKey: ["WSP_SEARCH", tenantId, propertyfilter, bussinessService],
+      queryFn: async () => await PTService.search({ tenantId: tenantId, filters: propertyfilter, auth: true }),
+      config: {
+        ...config,
+        enabled: !!(propertyids !== ""),
+      },
     }
   );
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSewSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSewSearch.js
@@ -1,15 +1,12 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS"
 
 //while registering it's name is WSuseSearch
-const useSewSearch = ({tenantId, filters, config={}}) => useQuery(
-    ["WS_SEW_SEARCH", tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
-    () => WSService.WSSewsearch({tenantId, filters}),
-    {
-        ...config
-    }
- )
+const useSewSearch = ({tenantId, filters, config={}}) => queryTemplate({
+    queryKey: ["WS_SEW_SEARCH", tenantId, ...Object.keys(filters)?.map( e => filters?.[e] )],
+    queryFn: () => WSService.WSSewsearch({tenantId, filters}),
+    config,
+ })
 
 
 export default useSewSearch

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSewarageSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSewarageSearch.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS";
 import { PTService } from "../../services/elements/PT";
 import _ from "lodash";
@@ -56,8 +56,7 @@ const combineResponse = (WaterConnections, properties, billData, t) => {
 }
 
 const useSewarageSearch = ({tenantId, filters = {}, BusinessService="WS", t}, config = {}) => {
-  const response = useQuery(['WS_SEARCH', tenantId, filters, BusinessService,config], async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService})
-  , config)
+  const response = queryTemplate({ queryKey: ['WS_SEARCH', tenantId, filters, BusinessService,config], queryFn: async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService}), config })
     let propertyids = "";
     let consumercodes = "";
     response?.data?.SewerageConnections?.forEach( item => {
@@ -67,13 +66,11 @@ const useSewarageSearch = ({tenantId, filters = {}, BusinessService="WS", t}, co
     let propertyfilter = { propertyIds : propertyids.substring(0, propertyids.length-1),}
     if(propertyids !== "" && filters?.locality) propertyfilter.locality = filters?.locality;
     config={...config,enabled:propertyids!==""?true:false}
-  const properties = useQuery(['WSP_SEARCH', tenantId, propertyfilter,BusinessService,config], async () => await PTService.search({ tenantId, filters:propertyfilter, auth:filters?.locality?false:true })
-  , config)
-  const billData = useQuery(['BILL_SEARCH', tenantId, consumercodes,BusinessService,config ], async () => await Digit.PaymentService.fetchBill(tenantId, {
+  const properties = queryTemplate({ queryKey: ['WSP_SEARCH', tenantId, propertyfilter,BusinessService,config], queryFn: async () => await PTService.search({ tenantId, filters:propertyfilter, auth:filters?.locality?false:true }), config })
+  const billData = queryTemplate({ queryKey: ['BILL_SEARCH', tenantId, consumercodes,BusinessService,config ], queryFn: async () => await Digit.PaymentService.fetchBill(tenantId, {
     businessService: BusinessService,
     consumerCode: consumercodes.substring(0, consumercodes.length-1),
-  })
-  , config)
+  }), config })
   return {isLoading:response?.isLoading || properties?.isLoading || billData?.isLoading, data : combineResponse(response?.data?.SewerageConnections,properties?.data?.Properties,billData?.data?.Bill, t)};
 
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSewerageCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useSewerageCreateAPI.js
@@ -1,8 +1,8 @@
 import { WSService } from "../../services/elements/WS";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useSewerageCreateAPI = (businessService = "WATER") => {
-    return useMutation((data) => WSService.create(data, businessService));
+    return mutationTemplate({ mutationFn: (data) => WSService.create(data, businessService) });
 };
 
 export default useSewerageCreateAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSApplicationDetailsBillAmendment.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSApplicationDetailsBillAmendment.js
@@ -1,12 +1,12 @@
 import { WSSearch } from "../../services/molecules/WS/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useWSApplicationDetailsBillAmendment = (t, tenantId, applicationNumber, serviceType, config = {}) => {
-  return useQuery(
-    ["APPLICATION_WS_SEARCH", "WNS_SEARCH", tenantId, applicationNumber, serviceType],
-    () => WSSearch.applicationDetailsBillAmendment(t, tenantId, applicationNumber, serviceType),
-    config
-  );
+  return queryTemplate({
+    queryKey: ["APPLICATION_WS_SEARCH", "WNS_SEARCH", tenantId, applicationNumber, serviceType],
+    queryFn: () => WSSearch.applicationDetailsBillAmendment(t, tenantId, applicationNumber, serviceType),
+    config,
+  });
 };
 
 export default useWSApplicationDetailsBillAmendment;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSConfigMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSConfigMDMS.js
@@ -1,12 +1,11 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const useWSConfigMDMS = {
   WSCreateConfig: (tenantId, config) =>
-    useQuery(
-      [tenantId, "FORM_WS_ACTIVATION_CONFIG"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, "FORM_WS_ACTIVATION_CONFIG"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -26,13 +25,12 @@ const useWSConfigMDMS = {
           },
           "WS"
         ),
-      { select: (d) => d["ws-services-masters"].WSCreateConfig, ...config }
-    ),
+      select: (d) => d["ws-services-masters"].WSCreateConfig, config }),
 
   WSActivationConfig: (tenantId, config) =>
-    useQuery(
-      [tenantId, "FORM_WS_ACTIVATION_CONFIG"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, "FORM_WS_ACTIVATION_CONFIG"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -52,13 +50,12 @@ const useWSConfigMDMS = {
           },
           "WS"
         ),
-      { select: (d) => d["ws-services-masters"].WSActivationConfig, ...config }
-    ),
+      select: (d) => d["ws-services-masters"].WSActivationConfig, config }),
 
   WSDisconnectionConfig: (tenantId, config) =>
-    useQuery(
-      [tenantId, "FORM_WS_ACTIVATION_CONFIG"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, "FORM_WS_ACTIVATION_CONFIG"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -78,13 +75,12 @@ const useWSConfigMDMS = {
           },
           "WS"
         ),
-      { select: (d) => d["ws-services-masters"].WSDisconnectionConfig, ...config }
-    ),
+      select: (d) => d["ws-services-masters"].WSDisconnectionConfig, config }),
   
     getFormConfig: (tenantId, config) =>
-    useQuery(
-      [tenantId, "FORM_CONFIG"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, "FORM_CONFIG"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -110,8 +106,7 @@ const useWSConfigMDMS = {
           },
           "ws-services-masters"
         ),
-      { select: (d) => d?.["ws-services-masters"], ...config }
-    ),
+      select: (d) => d?.["ws-services-masters"], config }),
 };
 
 export default useWSConfigMDMS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSDetailsPage.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSDetailsPage.js
@@ -1,12 +1,12 @@
 import { WSSearch } from "../../services/molecules/WS/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useWSDetailsPage = (t, tenantId, applicationNumber, serviceType, userInfo, config = {}) => {
-  return useQuery(
-    ["APPLICATION_WS_SEARCH", "WNS_SEARCH", applicationNumber, serviceType, userInfo,config],
-    () => WSSearch.applicationDetails(t, tenantId, applicationNumber, serviceType, userInfo),
-    {...config}
-  );
+  return queryTemplate({
+    queryKey: ["APPLICATION_WS_SEARCH", "WNS_SEARCH", applicationNumber, serviceType, userInfo,config],
+    queryFn: () => WSSearch.applicationDetails(t, tenantId, applicationNumber, serviceType, userInfo),
+    config,
+  });
 };
 
 export default useWSDetailsPage;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSDocumentSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSDocumentSearch.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 const useWSDocumentSearch = ({ application }, config = {}, Code, index) => {
   const client = useQueryClient();
@@ -12,8 +13,8 @@ const useWSDocumentSearch = ({ application }, config = {}, Code, index) => {
     newDocs.push(ob);
   })
   const filesArray = newDocs.map((value) => value?.fileStoreId);
-  const { isLoading, error, data } = useQuery([`ptDocuments-${propertyId}`, filesArray], () => Digit.UploadServices.Filefetch(filesArray, tenant));
-  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries([`ptDocuments-${propertyId}`, filesArray]) };
+  const { isLoading, error, data } = queryTemplate({ queryKey: [`ptDocuments-${propertyId}`, filesArray], queryFn: () => Digit.UploadServices.Filefetch(filesArray, tenant) });
+  return { isLoading, error, data: { pdfFiles: data?.data }, revalidate: () => client.invalidateQueries({ queryKey: [`ptDocuments-${propertyId}`, filesArray] }) };
 };
 
 export default useWSDocumentSearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSMDMS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSMDMS.js
@@ -1,19 +1,19 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const useWSMDMS = (tenantId, moduleCode, type, config = {}, payload = []) => {
   const queryConfig = { staleTime: Infinity, ...config };
   const useDocumentMapping = () => {
-    return useQuery('DOCUMENT_MAPPING', () => MdmsService.getDocumentTypes(tenantId, moduleCode, type), queryConfig);
+    return queryTemplate({ queryKey: ['DOCUMENT_MAPPING'], queryFn: () => MdmsService.getDocumentTypes(tenantId, moduleCode, type), config: queryConfig });
   }
   const useTradeTypetoRoleMapping = () => {
-    return useQuery('ROLE_DOCUMENT_MAPPING', () => MdmsService.getTradeTypeRoleTypes(tenantId, moduleCode, type), queryConfig);
+    return queryTemplate({ queryKey: ['ROLE_DOCUMENT_MAPPING'], queryFn: () => MdmsService.getTradeTypeRoleTypes(tenantId, moduleCode, type), config: queryConfig });
   }
   const useTaxHeadMasterMapping = () => {
-    return useQuery("TAX_HEAD_MASTER", ()=> MdmsService.getWSTaxHeadMaster(tenantId, moduleCode, type), queryConfig)
+    return queryTemplate({ queryKey: ["TAX_HEAD_MASTER"], queryFn: ()=> MdmsService.getWSTaxHeadMaster(tenantId, moduleCode, type), config: queryConfig })
   }
   const _default = () => {
-    return useQuery([tenantId, moduleCode, type], () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config);
+    return queryTemplate({ queryKey: [tenantId, moduleCode, type], queryFn: () => MdmsService.getMultipleTypes(tenantId, moduleCode, type), config });
   };
 
   switch (type) {

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSMDMSWS.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSMDMSWS.js
@@ -1,12 +1,11 @@
-import React from "react";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { MdmsService } from "../../services/elements/MDMS";
 
 const useWSMDMSWS = {
   applicationTypes: (tenantId) =>
-    useQuery(
-      [tenantId, "WS_WS_SERVICES_MASTERS"],
-      () =>
+    queryTemplate({
+      queryKey: [tenantId, "WS_WS_SERVICES_MASTERS"],
+      queryFn: () =>
         MdmsService.getDataByCriteria(
           tenantId,
           {
@@ -26,14 +25,12 @@ const useWSMDMSWS = {
           },
           "ws-services-masters"
         ),
-      {
-        select: (data) =>
+      select: (data) =>
           data["ws-services-masters"].ApplicationType.map((type) => ({
             code: type.code,
             i18nKey: `WS_${type.code}`,
           })),
-      }
-    ),
+    }),
 };
 
 export default useWSMDMSWS;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSModifyDetailsPage.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSModifyDetailsPage.js
@@ -1,12 +1,12 @@
 import { WSSearch } from "../../services/molecules/WS/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useWSModifyDetailsPage = (t, tenantId, applicationNumber, serviceType, userInfo, config = {}) => {
-  return useQuery(
-    ["APPLICATION_WS_SEARCH", "WNS_SEARCH", applicationNumber, serviceType, userInfo, config],
-    () => WSSearch.modifyApplicationDetails(t, tenantId, applicationNumber, serviceType, userInfo),
-    { ...config }
-  );
+  return queryTemplate({
+    queryKey: ["APPLICATION_WS_SEARCH", "WNS_SEARCH", applicationNumber, serviceType, userInfo, config],
+    queryFn: () => WSSearch.modifyApplicationDetails(t, tenantId, applicationNumber, serviceType, userInfo),
+    config,
+  });
 };
 
 export default useWSModifyDetailsPage;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSUpdateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWSUpdateAPI.js
@@ -1,8 +1,8 @@
 import { WSService } from "../../services/elements/WS";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useWSUpdateAPI = (businessService = "WATER") => {
-    return useMutation((data) =>  WSService.update(data, businessService));
+    return mutationTemplate({ mutationFn: (data) =>  WSService.update(data, businessService) });
 };
 
 export default useWSUpdateAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWaterCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWaterCreateAPI.js
@@ -1,8 +1,8 @@
 import { WSService } from "../../services/elements/WS";
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 
 const useWaterCreateAPI = (businessService = "WATER") => {
-    return useMutation((data) => WSService.create(data, businessService));
+    return mutationTemplate({ mutationFn: (data) => WSService.create(data, businessService) });
 };
 
 export default useWaterCreateAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWaterPropertySearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWaterPropertySearch.js
@@ -1,14 +1,14 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 import { PTService } from "../../services/elements/PT";
 
 const useWaterPropertySearch = ({tenantId, filters = {}, BusinessService="WS", t}, config = {}) => {
     let propertyfilter = { propertyIds : filters?.propertyids,}
     if(filters?.propertyids !== "" && filters?.locality) propertyfilter.locality = filters?.locality;
     config={enabled:filters?.propertyids!==""?true:false}
-    const { isLoading, error, data, isSuccess } = useQuery(['WSP_SEARCH', tenantId, propertyfilter,BusinessService], async () => await PTService.search({ tenantId, filters:propertyfilter, auth:filters?.locality?false:true })
-  , config)
+    const { isLoading, error, data, isSuccess } = queryTemplate({ queryKey: ['WSP_SEARCH', tenantId, propertyfilter,BusinessService], queryFn: async () => await PTService.search({ tenantId, filters:propertyfilter, auth:filters?.locality?false:true }), config })
   
-  return {isLoading,error, data, isSuccess, revalidate: () => client.invalidateQueries(["WSSearchList", tenantId, filters, auth]) };
+  return {isLoading,error, data, isSuccess, revalidate: () => client.invalidateQueries({ queryKey: ["WSP_SEARCH", tenantId, propertyfilter, BusinessService] }) };
 }
 
 export default useWaterPropertySearch;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWaterSearch.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/ws/useWaterSearch.js
@@ -1,4 +1,4 @@
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 import { WSService } from "../../services/elements/WS";
 import { PTService } from "../../services/elements/PT";
 import _ from "lodash";
@@ -57,8 +57,7 @@ const combineResponse = (WaterConnections, properties, billData, t) => {
 
 const useWaterSearch = ({tenantId, filters = {}, BusinessService="WS", t}, config = {}) => {
   
-  const response = useQuery(['WS_SEARCH', tenantId, filters, BusinessService,config], async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService})
-  , {...config})
+  const response = queryTemplate({ queryKey: ['WS_SEARCH', tenantId, filters, BusinessService,config], queryFn: async () => await WSService.search({tenantId, filters: { ...filters }, businessService:BusinessService}), config: {...config} })
     let propertyids = "";
     let consumercodes = "";
     if(BusinessService === "WS")
@@ -74,13 +73,11 @@ const useWaterSearch = ({tenantId, filters = {}, BusinessService="WS", t}, confi
     let propertyfilter = { propertyIds : propertyids.substring(0, propertyids.length-1),}
     if(propertyids !== "" && filters?.locality) propertyfilter.locality = filters?.locality;
     config={...config,enabled:propertyids!==""?true:false}
-  const properties = useQuery(['WSP_SEARCH', tenantId, propertyfilter,BusinessService,config], async () => await PTService.search({ tenantId, filters:propertyfilter, auth:filters?.locality?false:true })
-  , {...config})
-  const billData = useQuery(['BILL_SEARCH', tenantId, consumercodes,BusinessService,config ], async () => await Digit.PaymentService.fetchBill(tenantId, {
+  const properties = queryTemplate({ queryKey: ['WSP_SEARCH', tenantId, propertyfilter,BusinessService,config], queryFn: async () => await PTService.search({ tenantId, filters:propertyfilter, auth:filters?.locality?false:true }), config: {...config} })
+  const billData = queryTemplate({ queryKey: ['BILL_SEARCH', tenantId, consumercodes,BusinessService,config ], queryFn: async () => await Digit.PaymentService.fetchBill(tenantId, {
     businessService: BusinessService,
     consumerCode: consumercodes.substring(0, consumercodes.length-1),
-  })
-  , {...config})
+  }), config: {...config} })
   return {isLoading:response?.isLoading || properties?.isLoading || billData?.isLoading, data : combineResponse(response?.data?.WaterConnection,properties?.data?.Properties,billData?.data?.Bill, t) };
 }
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMTApplicationAction.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMTApplicationAction.js
@@ -1,4 +1,4 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActionsMT from "../../services/molecules/WT/ApplicationUpdateActionMT";
 
 /* Hook for Mobile Toilet (MT) application updates.  
@@ -6,7 +6,7 @@ import ApplicationUpdateActionsMT from "../../services/molecules/WT/ApplicationU
  * Returns a object for triggering and managing the update process.  
  */
 const useMTApplicationAction = (tenantId) => {
-  return useMutation((applicationData) => ApplicationUpdateActionsMT(applicationData, tenantId));
+  return mutationTemplate({ mutationFn: (applicationData) => ApplicationUpdateActionsMT(applicationData, tenantId) });
 };
 
 export default useMTApplicationAction;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMTApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMTApplicationDetail.js
@@ -1,30 +1,22 @@
 import { MTSearch } from "../../services/molecules/WT/MTSearch";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 /*Custom React hook for fetching Mobile Toilet (MT) application details.
   - Calls `MTSearch.applicationDetails` to retrieve application details based on provided parameters.
   - Uses `react-query`'s `useQuery` to manage the fetching, caching, and updating of the data.
   - Transforms the response structure before returning it..*/
 const useMTApplicationDetail = (t, tenantId, applicationNo, config = {}, userType, args) => {
-    
-  
   const defaultSelect = (data) => {
-     let applicationDetails = data.applicationDetails.map((obj) => {
-      return obj;
-    });
-    
-    return {
-      applicationData : data,
-      applicationDetails
-    }
+    let applicationDetails = data.applicationDetails.map((obj) => obj);
+    return { applicationData: data, applicationDetails };
   };
 
-  return useQuery(
-    [ applicationNo, userType, args],
-    () => MTSearch.applicationDetails(t, tenantId, applicationNo, userType, args),
-    { select: defaultSelect, ...config }
- 
-  );
+  return queryTemplate({
+    queryKey: [applicationNo, userType, args],
+    queryFn: () => MTSearch.applicationDetails(t, tenantId, applicationNo, userType, args),
+    select: defaultSelect,
+    config,
+  });
 };
 
 export default useMTApplicationDetail;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMobileToiletCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMobileToiletCreateAPI.js
@@ -1,12 +1,11 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import { MTService } from "../../services/elements/MT";
+
 export const useMobileToiletCreateAPI = (tenantId, type = true) => {
- 
   if (type) {
-    return useMutation((data) => MTService.create(data, tenantId));
-  } 
-  else {
-    return useMutation((data) => MTService.update(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => MTService.create(data, tenantId) });
+  } else {
+    return mutationTemplate({ mutationFn: (data) => MTService.update(data, tenantId) });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMobileToiletSearchAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useMobileToiletSearchAPI.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 /**
  * Custom hook for executing an water Tanker search using React Query.
@@ -9,21 +10,16 @@ import { useQuery, useQueryClient } from "react-query";
  */
 const useMobileToiletSearchAPI = ({ tenantId, filters, auth }, config = {}) => {
   const client = useQueryClient();
-
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
 
   const defaultSelect = (data) => {
-    if(data.mobileToiletBookingDetails.length >0)  data.mobileToiletBookingDetails[0].bookingNo = data.mobileToiletBookingDetails[0].bookingNo || [];
+    if (data.mobileToiletBookingDetails.length > 0) data.mobileToiletBookingDetails[0].bookingNo = data.mobileToiletBookingDetails[0].bookingNo || [];
     return data;
   };
 
-  const { isLoading, error, data, isSuccess,refetch } = useQuery([tenantId, filters, auth, config], () => Digit.MTService.search(args), {
-    
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess, refetch } = queryTemplate({ queryKey: [tenantId, filters, auth, config], queryFn: () => Digit.MTService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess,refetch, revalidate: () => client.invalidateQueries([tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, refetch, revalidate: () => client.invalidateQueries({ queryKey: [tenantId, filters, auth] }) };
 };
 
 export default useMobileToiletSearchAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTPApplicationAction.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTPApplicationAction.js
@@ -1,4 +1,4 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActionsTP from "../../services/molecules/WT/ApplicationUpdateActionTP";
 
 /* Hook for Tree Pruning (TP) application updates.  
@@ -6,7 +6,7 @@ import ApplicationUpdateActionsTP from "../../services/molecules/WT/ApplicationU
  * Returns a object for triggering and managing the update process.  
  */
 const useTPApplicationAction = (tenantId) => {
-  return useMutation((applicationData) => ApplicationUpdateActionsTP(applicationData, tenantId));
+  return mutationTemplate({ mutationFn: (applicationData) => ApplicationUpdateActionsTP(applicationData, tenantId) });
 };
 
 export default useTPApplicationAction;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTPApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTPApplicationDetail.js
@@ -1,30 +1,22 @@
 import { TPSearch } from "../../services/molecules/WT/TPSearch";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 /*Custom React hook for fetching Tree Pruning (TP) application details.
   - Calls `TPSearch.applicationDetails` to retrieve application details based on provided parameters.
   - Uses `react-query`'s `useQuery` to manage the fetching, caching, and updating of the data.
   - Transforms the response structure before returning it..*/
 const useTPApplicationDetail = (t, tenantId, applicationNo, config = {}, userType, args) => {
-    
-  
   const defaultSelect = (data) => {
-     let applicationDetails = data.applicationDetails.map((obj) => {
-      return obj;
-    });
-    
-    return {
-      applicationData : data,
-      applicationDetails
-    }
+    let applicationDetails = data.applicationDetails.map((obj) => obj);
+    return { applicationData: data, applicationDetails };
   };
 
-  return useQuery(
-    [ applicationNo, userType, args],
-    () => TPSearch.applicationDetails(t, tenantId, applicationNo, userType, args),
-    { select: defaultSelect, ...config }
- 
-  );
+  return queryTemplate({
+    queryKey: [applicationNo, userType, args],
+    queryFn: () => TPSearch.applicationDetails(t, tenantId, applicationNo, userType, args),
+    select: defaultSelect,
+    config,
+  });
 };
 
 export default useTPApplicationDetail;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTankerCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTankerCreateAPI.js
@@ -1,14 +1,11 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import { WTService } from "../../services/elements/WT";
 
-
 export const useTankerCreateAPI = (tenantId, type = true) => {
- 
   if (type) {
-    return useMutation((data) => WTService.create(data, tenantId));
-  } 
-  else {
-    return useMutation((data) => WTService.update(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => WTService.create(data, tenantId) });
+  } else {
+    return mutationTemplate({ mutationFn: (data) => WTService.update(data, tenantId) });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTankerSearchAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTankerSearchAPI.js
@@ -1,4 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 
 /**
  * Custom hook for executing an water Tanker search using React Query.
@@ -9,22 +10,16 @@ import { useQuery, useQueryClient } from "react-query";
  */
 const useTankerSearchAPI = ({ tenantId, filters, auth }, config = {}) => {
   const client = useQueryClient();
-
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
 
   const defaultSelect = (data) => {
-    if(data.waterTankerBookingDetail.length > 0)  data.waterTankerBookingDetail[0].bookingNo = data.waterTankerBookingDetail[0].bookingNo || [];
-      
+    if (data.waterTankerBookingDetail.length > 0) data.waterTankerBookingDetail[0].bookingNo = data.waterTankerBookingDetail[0].bookingNo || [];
     return data;
   };
 
-  const { isLoading, error, data, isSuccess,refetch } = useQuery(["wtSearchList", tenantId, filters, auth, config], () => Digit.WTService.search(args), {
-    
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess, refetch } = queryTemplate({ queryKey: ["wtSearchList", tenantId, filters, auth, config], queryFn: () => Digit.WTService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess,refetch, revalidate: () => client.invalidateQueries(["wtSearchList", tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, refetch, revalidate: () => client.invalidateQueries({ queryKey: ["wtSearchList", tenantId, filters, auth] }) };
 };
 
 export default useTankerSearchAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTreePruningCreateAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTreePruningCreateAPI.js
@@ -1,12 +1,11 @@
-import { useMutation } from "react-query";
+import { mutationTemplate } from "../../common/mutationTemplate";
 import { TPService } from "../../services/elements/TP";
+
 export const useTreePruningCreateAPI = (tenantId, type = true) => {
- 
   if (type) {
-    return useMutation((data) => TPService.create(data, tenantId));
-  } 
-  else {
-    return useMutation((data) => TPService.update(data, tenantId));
+    return mutationTemplate({ mutationFn: (data) => TPService.create(data, tenantId) });
+  } else {
+    return mutationTemplate({ mutationFn: (data) => TPService.update(data, tenantId) });
   }
 };
 

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTreePruningSearchAPI.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useTreePruningSearchAPI.js
@@ -1,5 +1,5 @@
-import { useQuery, useQueryClient } from "react-query";
-
+import { queryTemplate } from "../../common/queryTemplate";
+import { useQueryClient } from "../../common/queryClientTemplate";
 /**
  * Custom hook for executing an water Tanker search using React Query.
  * 
@@ -9,22 +9,16 @@ import { useQuery, useQueryClient } from "react-query";
  */
 const useTreePruningSearchAPI = ({ tenantId, filters, auth }, config = {}) => {
   const client = useQueryClient();
-
   const args = tenantId ? { tenantId, filters, auth } : { filters, auth };
 
   const defaultSelect = (data) => {
-   
-    if(data.treePruningBookingDetails.length >0)  data.treePruningBookingDetails[0].bookingNo = data.treePruningBookingDetails[0].bookingNo || [];
+    if (data.treePruningBookingDetails.length > 0) data.treePruningBookingDetails[0].bookingNo = data.treePruningBookingDetails[0].bookingNo || [];
     return data;
   };
 
-  const { isLoading, error, data, isSuccess,refetch } = useQuery(["tp_search_list_cache_key", tenantId, filters, auth, config], () => Digit.TPService.search(args), {
-    
-    select: defaultSelect,
-    ...config,
-  });
+  const { isLoading, error, data, isSuccess, refetch } = queryTemplate({ queryKey: ["tp_search_list_cache_key", tenantId, filters, auth, config], queryFn: () => Digit.TPService.search(args), select: defaultSelect, config });
 
-  return { isLoading, error, data, isSuccess,refetch, revalidate: () => client.invalidateQueries([tenantId, filters, auth]) };
+  return { isLoading, error, data, isSuccess, refetch, revalidate: () => client.invalidateQueries({ queryKey: [tenantId, filters, auth] }) };
 };
 
 export default useTreePruningSearchAPI;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useWTApplicationAction.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useWTApplicationAction.js
@@ -1,10 +1,8 @@
-import { useMutation } from "react-query";
-
+import { mutationTemplate } from "../../common/mutationTemplate";
 import ApplicationUpdateActionsWT from "../../services/molecules/WT/ApplicationUpdateActionsWT";
 
 const useWTApplicationAction = (tenantId) => {
-  
-  return useMutation((applicationData) => ApplicationUpdateActionsWT(applicationData, tenantId));
+  return mutationTemplate({ mutationFn: (applicationData) => ApplicationUpdateActionsWT(applicationData, tenantId) });
 };
 
 export default useWTApplicationAction;

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useWTApplicationDetail.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/wt/useWTApplicationDetail.js
@@ -1,26 +1,18 @@
 import { WTSearch } from "../../services/molecules/WT/Search";
-import { useQuery } from "react-query";
+import { queryTemplate } from "../../common/queryTemplate";
 
 const useWTApplicationDetail = (t, tenantId, applicationNo, config = {}, userType, args) => {
-    
-  
   const defaultSelect = (data) => {
-     let applicationDetails = data.applicationDetails.map((obj) => {
-      return obj;
-    });
-    
-    return {
-      applicationData : data,
-      applicationDetails
-    }
+    let applicationDetails = data.applicationDetails.map((obj) => obj);
+    return { applicationData: data, applicationDetails };
   };
 
-  return useQuery(
-    ["APPLICATION_SEARCH", "WT_SEARCH", applicationNo, userType, args],
-    () => WTSearch.applicationDetails(t, tenantId, applicationNo, userType, args),
-    { select: defaultSelect, ...config }
- 
-  );
+  return queryTemplate({
+    queryKey: ["APPLICATION_SEARCH", "WT_SEARCH", applicationNo, userType, args],
+    queryFn: () => WTSearch.applicationDetails(t, tenantId, applicationNo, userType, args),
+    select: defaultSelect,
+    config,
+  });
 };
 
 export default useWTApplicationDetail;


### PR DESCRIPTION
Migrate react-query v3 to @tanstack/react-query v5 React Hooks  folders and files.

Updated files:
- UseCustomBackNavigationProps.js
- index.js
- payment.js
- revalidateQuery.js
- store.js
- useAccessControl.js
- useApplicationForBillSearch.js
- useClickOutside.js
- useCustomAPIHook.js
- useCustomMDMS.js
- useCustomMDMSV2.js
- useCustomNavigate.js
- useDocumentSearch.js
- useDynamicData.js
- useEmployeeSearch.js
- useEnabledMDMS.js
- useFeedBackSearch.js
- useGetDSSAboutJSON.js
- useGetDSSFAQsJSON.js
- useGetFAQsJSON.js
- useHowItWorksJSON.js
- useInbox.js
- useLocalities.js
- useMDMS.js
- useMDMSV2.js
- useModuleTenants.js
- usePrivacyContext.js
- useQueryParams.js
- useRouteSubscription.js
- useSelectedMDMS.js
- useSessionStorage.js
- useStaticData.js
- useStatusGeneral.js
- useStore.js
- useTenants.js
- userSearch.js
- workflow.js
- useCustomNavigate.js

Folder:
- pt
- ptr
- receipts
- reports
- surveys
- sv
- tl
- useInboxGeneral
- vendor
- ws
- wt