### PR TITLE
Fix calculation context path in application.properties

### DIFF
--- a/municipal-services/pt-services-v2/src/main/resources/application.properties
+++ b/municipal-services/pt-services-v2/src/main/resources/application.properties
@@ -86,7 +86,7 @@ egov.location.endpoint=boundarys/_search
 
 #Calculation config
 egov.calculation.host=http://pt-calculator-v2:8080/
-egov.calculation.context.path=pt-calculator-v2/propertytax
+egov.calculation.context.path=pt-calculator-v2/propertytax/
 egov.calculation.endpoint=_calculate
 
 


### PR DESCRIPTION
Updated calculation context path to include trailing slash.