### PR TITLE
Fix What's New notification rendering on citizen dashboard

### DIFF
--- a/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/events/index.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/libraries/src/hooks/events/index.js
@@ -111,7 +111,7 @@ e?.eventDetails?.documents?.length && e?.tenantId
 ? await fetchImageLinksFromFilestoreIds(e.eventDetails.documents, e.tenantId)
 : [];
 
-```
+
 const sla = getEventSLA(e);
 
 events.push({
@@ -126,7 +126,7 @@ events.push({
     ? timeStampBreakdown(e.eventDetails.fromDate, e.eventDetails.toDate)
     : {}),
 });
-```
+
 
 }
 
@@ -135,10 +135,6 @@ return events;
 
 const variantBasedFilter = async (variant, data) => {
 const events = await filterAllEvents(data.events, variant);
-
-if (variant === "whats-new") {
-return events.filter((i) => i?.actions?.length);
-}
 
 return events;
 };

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/modules/core/src/pages/citizen/Home/index.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/modules/core/src/pages/citizen/Home/index.js
@@ -239,7 +239,7 @@ useEffect(() => {
         {conditionsToDisableNotificationCountTrigger() ? (
           EventsDataLoading ? (
             <Loader />
-          ) : (
+          ) : EventsData?.length > 0 ? (
             <div className="WhatsNewSection">
               <div className="headSection">
                 <h2>{t(whatsNewSectionObj?.headerLabel)}</h2>
@@ -247,7 +247,7 @@ useEffect(() => {
               </div>
               <WhatsNewCard {...EventsData?.[0]} />
             </div>
-          )
+          ) : null
         ) : null}
        {/* <ChatBot /> text bot commented as we are using new speech bot*/} 
        <UpyogBot />


### PR DESCRIPTION
## Issue

The What's New section on the citizen dashboard was not aligned with the notification list.

Notifications without actions were excluded from the What's New data set, causing the first notification displayed in What's New to differ from the notification list. In addition, the section could render with invalid data when no notifications were available.

## Changes Made

- Removed the variant-specific filtering for `whats-new` notifications.
- Ensured the What's New section uses the same notification data source as the notification list.
- Added a guard to render the What's New section only when notification data is available.

## Result

- The first notification displayed in What's New now matches the first notification in the notification list.
- Notifications without actions are also included.
- The What's New section is hidden when no notifications exist.

## Testing

- Verified notifications are fetched successfully.
- Verified the first notification is displayed in What's New.
- Verified the section is not rendered when notifications are unavailable.