### PR TITLE
replace egovio maven builder image with upyogio alpine-maven-3.9-builder-jdk-8

### DIFF
--- a/finance/Dockerfile
+++ b/finance/Dockerfile
@@ -1,4 +1,5 @@
-FROM egovio/alpine-maven-builder-jdk-8:gcp AS build
+#FROM egovio/alpine-maven-builder-jdk-8:gcp AS build
+FROM upyogio/alpine-maven-3.9-builder-jdk-8:gcp-v2 AS build
 ARG WORK_DIR
 WORKDIR /app
 


### PR DESCRIPTION
The previous image used an older Maven version that failed to validate the 
newer SSL certificate (E36) used by the dependency repository, causing build 
failures during `mvn clean package`. The upyogio image includes Maven 3.9, 
which supports the updated certificate and resolves the issue.