### PR TITLE
Fix mobile number login consent

### DIFF
--- a/frontend/upyog-ui/web/micro-ui-internals/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/modules/core/src/pages/citizen/Login/SelectMobileNumber.js
@@ -36,7 +36,7 @@ const SelectMobileNumber = ({ t, onSelect, showRegisterLink, mobileNumber, onMob
     return (
     <span>
       {isCCFEnabled?.checkBoxLabels?.map((data, index) => {
-        return <span>
+        <span key={data?.linkId || index}>
           {/* {index == 0 && "CCF"} */}
           {data?.linkPrefix && <span>{t(`${data?.linkPrefix}_`)}</span>}
           {data?.link && <span id={data?.linkId} onClick={(e) => { onLinkClick(e) }} style={{ color: "#a82227", cursor: "pointer" }}>{t(`${data?.link}_`)}</span>}
@@ -133,7 +133,18 @@ const SelectMobileNumber = ({ t, onSelect, showRegisterLink, mobileNumber, onMob
         />
       </div>)}
       <div className="col col-md-4  text-md-center p-0" style={{width:"40%", marginTop:"5px"}}>
-             <button className="digilocker-btn"type="submit" onClick={(e)=>setShowToast(true)   }><img src="https://meripehchaan.gov.in/assets/img/icon/digi.png" class="mr-2" style={{"width":"12%"}}></img>Register/Login with DigiLocker</button>
+        <button
+          className="digilocker-btn"
+          type="button"
+          onClick={(e) => setShowToast(true)}
+        >
+          <img
+          src="https://meripehchaan.gov.in/assets/img/icon/digi.png"
+          className="mr-2"
+          style={{ width: "12%" }}
+          />
+          Register/Login with DigiLocker
+        </button>
      { showToast &&   <Modal
       headerBarMain={<Heading label={t("Consent")} />}
       headerBarEnd={<CloseBtn onClick={closeModal} />}

--- a/frontend/upyog-ui/web/micro-ui-internals/packages/react-components/src/molecules/FormStep.js
+++ b/frontend/upyog-ui/web/micro-ui-internals/packages/react-components/src/molecules/FormStep.js
@@ -36,7 +36,8 @@ const FormStep = ({
   });
 // console.log("_defaultValues", _defaultValues);
   const goNext = (data) => {
-    onSelect(data);
+    if (isDisable) return;
+      onSelect(data); 
   };
 
   const isDisable =


### PR DESCRIPTION
Citizen Login Consent Validation Fix

Issue:
Users could bypass the mandatory consent checkbox on the Citizen Login page by pressing Enter, which generated an OTP and navigated to the OTP page without consent.

Root Cause:
Consent validation was enforced only through the disabled state of the Continue button. Keyboard form submission (Enter key) bypassed this validation and directly triggered the login flow.

Solution:
Enforced validation within the form submission flow to prevent progression when the form is in a disabled state. Also updated the DigiLocker button behaviour to avoid unintended form submission triggers.

Expected Behaviour:

Consent unchecked + Continue click --> Blocked
Consent unchecked + Enter key --> Blocked
Consent checked + Continue click --> OTP generated
Consent checked + Enter key --> OTP generated

Impact:
Ensures mandatory consent compliance and consistent behaviour across all login submission methods.