### PR TITLE
Add moduleName-based schema search with minimum character validation

### DIFF
--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/model/SchemaDefCriteria.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/model/SchemaDefCriteria.java
@@ -37,6 +37,9 @@ public class SchemaDefCriteria {
     @JsonProperty("limit")
     private Integer limit;
 
+    @JsonProperty("moduleName")
+    private String moduleName;
+
 
     public SchemaDefCriteria addCodesItem(String codesItem) {
         if (this.codes == null) {

--- a/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/querybuilder/SchemaDefinitionQueryBuilder.java
+++ b/core-services/mdms-v2/src/main/java/org/egov/infra/mdms/repository/querybuilder/SchemaDefinitionQueryBuilder.java
@@ -53,6 +53,20 @@ public class SchemaDefinitionQueryBuilder {
             builder.append(" schema.code IN ( ").append(QueryUtil.createQuery(schemaDefCriteria.getCodes().size())).append(" )");
             QueryUtil.addToPreparedStatement(preparedStmtList, new HashSet<>(schemaDefCriteria.getCodes()));
         }
+        if (!Objects.isNull(schemaDefCriteria.getModuleName())) {
+
+            String moduleName = schemaDefCriteria.getModuleName().trim();
+
+            if (moduleName.length() < 3) {
+                throw new IllegalArgumentException(
+                    "Minimum 3 characters are required for module search."
+                );
+            }
+
+            QueryUtil.addClauseIfRequired(builder, preparedStmtList);
+            builder.append(" schema.code ILIKE ? ");
+            preparedStmtList.add(moduleName + "%.%");
+        }
 
         return builder.toString();
     }


### PR DESCRIPTION
Added support for searching schema definitions using moduleName. Also added validation to enforce a minimum of 3 characters for module name search, returning a 400 response for invalid requests.